### PR TITLE
ci(*): add build.yml and address some npm test errors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,44 @@
+name: Build
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Setup Spin
+        uses: fermyon/actions/spin/setup@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install bart
+        run: |
+          curl -LOs https://github.com/fermyon/bartholomew/releases/download/v0.10.0/bart
+          chmod +x bart
+          mv bart /usr/local/bin
+
+      - name: Check Docs
+        run: |
+          bart check --shortcodes shortcodes content/* && bart check --shortcodes shortcodes content/**/*
+      
+      - name: Install npm packages
+        run: |
+          npm ci
+          npm ci --prefix ./spin-up-hub
+
+      - name: Build app
+        run: |
+          spin build
+
+      - name: Run npm tests
+        run: |
+          npm test
+

--- a/content/v1/cli-reference.md
+++ b/content/v1/cli-reference.md
@@ -239,7 +239,6 @@ $ spin add --help
 spin-add 
 Scaffold a new component into an existing application
 
-
 USAGE:
     spin add [OPTIONS] [ARGS]
 

--- a/content/v1/index.md
+++ b/content/v1/index.md
@@ -6,7 +6,6 @@ enable_shortcodes = true
 canonical_url = "https://spinframework.com/v2/index"
 url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v1/index.md"
 
-
 ---
 
 Spin is a framework and CLI for building and running event-driven microservice applications with WebAssembly (Wasm) components. Spin uses Wasm because it is **sandboxed, portable, and fast**.  Millisecond cold start times mean no need to keep applications "warm".
@@ -20,7 +19,6 @@ Many languages have Wasm implementations, so **developers don't have to learn ne
 {{card_element "template" "Zola SSG Template" "A template for using Zola framework to create a static webpage" "/hub/preview/template_zola_ssg" "rust" true }}
 {{card_element "sample" "AI-assisted News Summarizer" "Read an RSS newsfeed and have AI summarize it for you" "/hub/preview/sample_newsreader_ai" "Typescript,Javascript,Ai" true }}
 {{blockEnd}}
-
 
 Or dive into the documentation and get started:
 

--- a/content/v1/kv-store-api-guide.md
+++ b/content/v1/kv-store-api-guide.md
@@ -117,7 +117,6 @@ The key value functions are provided through the `spin_key_value` module in the 
 from spin_http import Response
 from spin_key_value import kv_open_default
 
-
 def handle_request(request):
 
     store = kv_open_default()

--- a/content/v1/python-components.md
+++ b/content/v1/python-components.md
@@ -178,7 +178,6 @@ This next example will create an outbound request, to obtain a random fact about
 ```python
 from spin_http import Request, Response, http_send
 
-
 def handle_request(request):
 
     response = http_send(
@@ -272,7 +271,6 @@ If you are still following along, please go ahead and update your `app.py` file 
 from spin_http import Response
 from spin_redis import redis_del, redis_get, redis_incr, redis_set, redis_sadd, redis_srem, redis_smembers
 from spin_config import config_get
-
 
 def handle_request(request):
 

--- a/content/v1/quickstart.md
+++ b/content/v1/quickstart.md
@@ -802,7 +802,6 @@ Hello, Fermyon
 
 Congratulations! You just created, built and ran your first Spin application!
 
-
 ## Next Steps
 
 - Learn more about [writing Spin components and manifests](writing-apps)

--- a/content/v1/serverless-ai-api-guide.md
+++ b/content/v1/serverless-ai-api-guide.md
@@ -149,7 +149,6 @@ export const handleRequest: HandleRequest = async function (request: HttpRequest
 from spin_http import Response
 from spin_llm import llm_infer
 
-
 def handle_request(request):
     prompt="You are a stand up comedy writer. Tell me a joke."
     result=llm_infer("llama2-chat", prompt)

--- a/content/v1/serverless-ai-hello-world.md
+++ b/content/v1/serverless-ai-hello-world.md
@@ -269,7 +269,6 @@ def handle_request(request):
     except Exception as e:
         return Response(500, {"content-type": "text/plain"}, bytes(f"Error: {str(e)}", "utf-8"))
 
-
 ```
  
 {{ blockEnd }}

--- a/content/v2/build.md
+++ b/content/v2/build.md
@@ -68,7 +68,6 @@ command = "cargo build --target wasm32-wasi --release"
 
 For JavaScript and TypeScript applications, you must have [Node.js](https://nodejs.org).
 
-
 It's normally convenient to put the detailed build instructions in `package.json`. The build script looks like:
 
 <!-- @nocpy -->

--- a/content/v2/cli-reference.md
+++ b/content/v2/cli-reference.md
@@ -322,7 +322,6 @@ OPTIONS:
 
 {{ blockEnd }}
 
-
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -561,7 +560,6 @@ OPTIONS:
 
 {{ blockEnd }}
 
-
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -610,7 +608,6 @@ The `spin cloud` command is implemented by the [Fermyon Cloud Plugin](/cloud/clo
 The `spin cloud` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference).
 
 {{ blockEnd }}
-
 
 {{ blockEnd }}
 
@@ -661,7 +658,6 @@ The `spin cloud apps` command is implemented by the [Fermyon Cloud Plugin](/clou
 
 {{ blockEnd }}
 
-
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -710,7 +706,6 @@ The `spin cloud deploy` command is implemented by the [Fermyon Cloud Plugin](/cl
 The `spin cloud deploy` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-deploy).
 
 {{ blockEnd }}
-
 
 {{ blockEnd }}
 
@@ -761,7 +756,6 @@ The `spin cloud link` command is implemented by the [Fermyon Cloud Plugin](/clou
 
 {{ blockEnd }}
 
-
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -810,7 +804,6 @@ The `spin cloud login` command is implemented by the [Fermyon Cloud Plugin](/clo
 The `spin cloud login` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-login).
 
 {{ blockEnd }}
-
 
 {{ blockEnd }}
 
@@ -861,7 +854,6 @@ The `spin cloud sqlite` command is implemented by the [Fermyon Cloud Plugin](/cl
 
 {{ blockEnd }}
 
-
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -911,7 +903,6 @@ The `spin cloud unlink` command is implemented by the [Fermyon Cloud Plugin](/cl
 
 {{ blockEnd }}
 
-
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -960,7 +951,6 @@ The `spin cloud variables` command is implemented by the [Fermyon Cloud Plugin](
 The `spin cloud variables` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-variables).
 
 {{ blockEnd }}
-
 
 {{ blockEnd }}
 
@@ -1128,7 +1118,6 @@ OPTIONS:
 
 {{ blockEnd }}
 
-
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -1178,7 +1167,6 @@ OPTIONS:
 
 {{ blockEnd }}
 
-
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -1203,7 +1191,6 @@ The `spin kube` command is implemented by the [`spin-kube` plugin](https://www.s
 The `spin kube` command is implemented by the [`spin-kube` plugin](https://www.spinkube.dev/docs/reference/cli-reference/).
 
 {{ blockEnd }}
-
 
 {{ blockEnd }}
 
@@ -1230,7 +1217,6 @@ The `spin kube completion` command is implemented by the [`spin-kube` plugin](ht
 
 {{ blockEnd }}
 
-
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -1255,7 +1241,6 @@ The `spin kube scaffold` command is implemented by the [`spin-kube` plugin](http
 The `spin kube scaffold` command is implemented by the [`spin-kube` plugin](https://www.spinkube.dev/docs/reference/cli-reference/#spin-kube-scaffold).
 
 {{ blockEnd }}
-
 
 {{ blockEnd }}
 
@@ -1535,7 +1520,6 @@ OPTIONS:
 
 {{ blockEnd }}
 
-
 {{ blockEnd }}
 
 **Please note: `spin new` vs `spin add`**.  These commands are similar except that:
@@ -1743,7 +1727,6 @@ SUBCOMMANDS:
 ```
 
 {{ blockEnd }}
-
 
 {{ blockEnd }}
 
@@ -2039,7 +2022,6 @@ OPTIONS:
 
 {{ blockEnd }}
 
-
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -2193,8 +2175,8 @@ OPTIONS:
         --installed          List only installed plugins
         --summary            List latest and installed versions of plugins
 ```
-{{ blockEnd }}
 
+{{ blockEnd }}
 
 {{ blockEnd }}
 
@@ -2349,7 +2331,6 @@ OPTIONS:
 ```
 
 {{ blockEnd }}
-
 
 {{ blockEnd }}
 
@@ -2512,7 +2493,6 @@ OPTIONS:
 
 {{ blockEnd }}
 
-
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -2652,7 +2632,6 @@ OPTIONS:
 ```
 
 {{ blockEnd }}
-
 
 {{ blockEnd }}
 
@@ -2969,7 +2948,6 @@ OPTIONS:
 
 {{ blockEnd }}
 
-
 {{ blockEnd }}
 
 **Note:** For additional information, please see the [Managing Plugins](/spin/managing-plugins) and/or [Creating Plugins](/spin/plugin-authoring) sections of the documentation.
@@ -3146,7 +3124,6 @@ SUBCOMMANDS:
 ```
 
 {{ blockEnd }}
-
 
 {{ blockEnd }}
 
@@ -3329,7 +3306,6 @@ OPTIONS:
 ```
 
 {{ blockEnd }}
-
 
 {{ blockEnd }}
 
@@ -3519,7 +3495,6 @@ OPTIONS:
 ```
 
 {{ blockEnd }}
-
 
 {{ blockEnd }}
 
@@ -3754,7 +3729,6 @@ OPTIONS:
 
 {{ blockEnd }}
 
-
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -3969,7 +3943,6 @@ SUBCOMMANDS:
 ```
 
 {{ blockEnd }}
-
 
 {{ blockEnd }}
 
@@ -4230,7 +4203,6 @@ OPTIONS:
 
 {{ blockEnd }}
 
-
 {{ blockEnd }}
 
 <!-- markdownlint-disable-next-line titlecase-rule -->
@@ -4384,7 +4356,6 @@ OPTIONS:
 ```
 
 {{ blockEnd }}
-
 
 {{ blockEnd }}
 
@@ -4548,7 +4519,6 @@ OPTIONS:
 ```
 
 {{ blockEnd }}
-
 
 {{ blockEnd }}
 
@@ -4795,7 +4765,6 @@ OPTIONS:
 
 {{ blockEnd }}
 
-
 {{ blockEnd }}
 
 **Note:** For additional information, please see the [Managing Templates](/spin/managing-templates) and/or [Creating Templates](/spin/template-authoring) sections of the documentation.
@@ -4879,7 +4848,6 @@ Options:
 ```
 
 {{ blockEnd }}
-
 
 {{ blockEnd }}
 
@@ -5443,7 +5411,6 @@ HTTP TRIGGER OPTIONS:
 
 {{ blockEnd }}
 
-
 {{ blockEnd }}
 
 > **Please note:** If the `-f` or `--from` options do not accurately infer the intended registry or `.toml` file for your application, then you can explicitly specify either the `--from-registry` or  `--from-file` options to clarify this.
@@ -5631,7 +5598,6 @@ The following additional trigger options are available for the [spin up](#spin-u
 ```
 
 {{ blockEnd }}
-
 
 {{ blockEnd }}
 
@@ -5843,7 +5809,6 @@ OPTIONS:
 
 {{ blockEnd }}
 
-
 {{ blockEnd }}
 
 ## Stability Table
@@ -5975,6 +5940,5 @@ CLI commands have four phases that indicate levels of stability:
 | <code>spin watch</code>                                                               | Experimental |
 | <code>spin test</code>                                                                | Experimental |
 {{ blockEnd }}
-
 
 {{ blockEnd }}

--- a/content/v2/contributing-spin.md
+++ b/content/v2/contributing-spin.md
@@ -15,7 +15,6 @@ This document will guide you through making your first contribution to the proje
 We welcome and appreciate contributions of all types — opening issues, fixing
 typos, adding examples, one-liner code fixes, tests, or complete features.
 
-
 ## Developer Community Calls
 
 <div style="display: block" align="left">

--- a/content/v2/extending-and-embedding.md
+++ b/content/v2/extending-and-embedding.md
@@ -110,7 +110,7 @@ impl TriggerExecutor for TimerTrigger {
 }
 ```
 
-### The Trigger is an Executable
+### The Trigger Is an Executable
 
 A trigger is a separate program, so that it can be installed as a plugin. So it is a Rust `bin` project and has a `main` function. It can be useful to also provide a library crate, so that projects that embed Spin can load it in process if desired, but the timer sample doesn't currently show that.
 

--- a/content/v2/javascript-components.md
+++ b/content/v2/javascript-components.md
@@ -359,13 +359,11 @@ This library only currently supports the following polyfills:
 - `fs` - only implements `readFileSync` and `readdirSync`.
 - `os` - Implements only `EOL` and `arch`.
 
-
 ## Using External NPM Libraries
 
 > Not all the NPM packages are guaranteed to work with the SDK as it is not fully compatible with the browser or `Node.js`. It implements only a subset of the API.
 
 Some NPM packages can be installed and used in the component. If a popular library does not work, please open an issue/feature request in the [spin-js-sdk repository](https://github.com/spinframework/spin-js-sdk/issues).
-
 
 ### Suggested Libraries for Common Tasks
 

--- a/content/v2/key-value-store-tutorial.md
+++ b/content/v2/key-value-store-tutorial.md
@@ -147,7 +147,6 @@ key_value_stores = ["default"]
 ...
 ```
 
-
 ## Write Code to Save and Load Data
 
 In this section, we use the Spin SDK to open and persist our application's data inside our default key/value store. This is a special store that every environment running Spin applications will make available for their application. 
@@ -318,7 +317,6 @@ class IncomingHandler(http.IncomingHandler):
                     return Response(405, {"content-type": "text/plain"})
 
 {{ blockEnd }}
-
 
 {{ startTab "TinyGo" }}
 
@@ -521,4 +519,3 @@ Congratulations, you have a Spin application and associated Key Value store runn
 
 * Explore the contents of your Key Value store with the [Key Value Store Explorer template](../../hub/preview/template_kv_explorer)
 * Learn about linking your applications to different [Key Value Stores on Fermyon Cloud](../../cloud/kv-cloud-tutorial.md) 
-

--- a/content/v2/observing-apps.md
+++ b/content/v2/observing-apps.md
@@ -33,13 +33,14 @@ We have a plugin that makes it easy to use OpenTelemetry with Spin. If you would
   spin plugins update
   spin plugins install otel
   ```
+
 - To see the available commands, you can run `spin otel --help`
 
-## Configuring your own observability stack
+## Configuring Your Own Observability Stack
 
 Follow this portion of the guide if you want to use Spin and OTel, but want to have more control than what the OTel plugin offers.
 
-### Configure the Docker compose stack
+### Configure the Docker Compose Stack
 
 In order to view the telemetry data you need to run an OTel compliant [collector](https://opentelemetry.io/docs/collector/) and the proper backends for each signal type. If you have Docker on your system you can easily start all the observability tools you need with the following commands:
 

--- a/content/v2/quickstart.md
+++ b/content/v2/quickstart.md
@@ -554,6 +554,7 @@ source = "app.wasm"
 [component.hello-python.build]
 command = "componentize-py -w spin-http componentize app -o app.wasm"
 ```
+
 This represents a simple Spin HTTP application (triggered by an HTTP request).  It has:
 
 * A single HTTP trigger, for the `/...` route, associated with the `hello-python` component.  `/...` is a wildcard, meaning it will match any route.  When the application gets an HTTP request that matches this route - that is, any HTTP request at all! - Spin will run the `hello-python` component.

--- a/content/v2/registry-tutorial.md
+++ b/content/v2/registry-tutorial.md
@@ -102,12 +102,11 @@ Lastly, let's run this Spin application:
 $ spin up -f ghcr.io/USERNAME/spin-react-fullstack:v1
 ```
 
-## Deploy a Spin App from GHCR (or any registry)
+## Deploy a Spin App From GHCR (or Any Registry)
 
 You can deploy a Spin app from any registry such as GHCR or DockerHub using the CLI command `spin deploy -f <remote-reference-here>` 
 
 > **Note:** You need a Fermyon Cloud account to deploy to. The remote-reference can be private, as long as you are authenticated locally to the registry in question, since the CLI will pull it down prior to publishing it to Cloud's internal registry.
-
 
 ## Conclusion
 

--- a/content/v2/rust-components.md
+++ b/content/v2/rust-components.md
@@ -508,7 +508,7 @@ annotated using the `http_component` macro, compiled to the `wasm32-wasi` target
 This means that any [crate](https://crates.io) that compiles to `wasm32-wasi` can
 be used when implementing the component.
 
-### Using the `http` crate
+### Using the `http` Crate
 
 If you're already familiar with the popular [`http` crate](https://crates.io/crates/http), you may wish to use that instead of using the HTTP types included in the Spin SDK. Generally, the `http` crate's types can be used anywhere the Spin SDK HTTP types can be used. For example, the first basic HTTP component can be rewritten to use the `http` crate like so:
 

--- a/content/v2/see-what-people-have-built-with-spin.md
+++ b/content/v2/see-what-people-have-built-with-spin.md
@@ -19,7 +19,7 @@ url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v2/see-
 
 Spin can be used to build many different types of applications. The following blog articles show how different applications are built with Spin.
 
-## AI-powered bookmarking app with Python and WebAssembly
+## AI-Powered Bookmarking App with Python and WebAssembly
 
 [How to build an AI-powered bookmarking app with Python and WebAssembly](https://dev.to/fermyon/part-1-how-to-build-an-ai-powered-bookmarking-app-with-python-and-webassembly-2c5b).
 

--- a/content/v2/serverless-ai-api-guide.md
+++ b/content/v2/serverless-ai-api-guide.md
@@ -235,7 +235,7 @@ func init() {
 
 ## Troubleshooting
 
-### Error "Local LLM operations are not supported in this version of Spin"
+### Error "Local LLM Operations Are Not Supported in This Version of Spin"
 
 If you see "Local LLM operations are not supported in this version of Spin", then your copy of Spin has been built without local LLM support.
 

--- a/content/v2/serverless-ai-hello-world.md
+++ b/content/v2/serverless-ai-hello-world.md
@@ -63,7 +63,6 @@ python3 --version
 
 If you do not have Python 3.10 or later, you can install it by following the instructions [here](https://www.python.org/downloads/).
 
-
 To enable Serverless AI functionality via Python, please ensure you have the latest Python template installed:
 
 <!-- @selectiveCpy -->
@@ -335,7 +334,6 @@ class IncomingHandler(http.IncomingHandler):
             {"content-type": "text/plain"},
             bytes(res.text, "utf-8")
         )
-
 
 ```
  

--- a/content/v2/variables.md
+++ b/content/v2/variables.md
@@ -55,7 +55,6 @@ Variables can also be used in other sections of the application manifest that be
 allowed_outbound_hosts = [ "\{{ api_uri }}" ]
 ```
 
-
 All in all, an application manifest with `api_token` and `api_uri` variables and a component that uses them would look similar to the following:
 
 <!-- @nocpy -->

--- a/content/v3/build.md
+++ b/content/v3/build.md
@@ -70,7 +70,6 @@ command = "cargo build --target wasm32-wasip1 --release"
 
 For JavaScript and TypeScript applications, you must have [Node.js](https://nodejs.org).
 
-
 It's normally convenient to put the detailed build instructions in `package.json`. The build script looks like:
 
 <!-- @nocpy -->

--- a/content/v3/deploying.md
+++ b/content/v3/deploying.md
@@ -6,7 +6,7 @@ url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v3/depl
 
 ---
 
-### Running locally on your workstation 
+### Running Locally on Your Workstation 
 
 For instructions guiding you through running Spin apps on your development workstation,
 follow [this guide](/running-app).
@@ -14,7 +14,6 @@ follow [this guide](/running-app).
 ### Deploying to Kubernetes
 
 Spin applications can be deployed to a Kubernetes cluster with [SpinKube](https://www.spinkube.dev/docs/overview/) - an open source project that streamlines the experience of developing, deploying, and operating Wasm workloads on Kubernetes. Like Spin, SpinKube is a CNCF Sandbox project.
-
 
 ## Fermyon Cloud
 

--- a/content/v3/extending-and-embedding.md
+++ b/content/v3/extending-and-embedding.md
@@ -111,7 +111,7 @@ impl<F: RuntimeFactors> Trigger<F> for TimerTrigger {
 
 The `Trigger` trait is generic in the set of _factors_ supported by the trigger - this is roughly the set of APIs available to guest code. In most circumstances, your implementation should also be generic, as shown, because your trigger is only concerned with detecting events, and can do that regardless of what APIs are available to the guests that handle those events.
 
-### The Trigger is an Executable
+### The Trigger Is an Executable
 
 A trigger is a separate program, so that it can be installed as a plugin. So it is a Rust `bin` project and has a `main` function. It can be useful to also provide a library crate, so that projects that embed Spin can load it in process if desired, but the timer sample doesn't currently show that.
 

--- a/content/v3/javascript-components.md
+++ b/content/v3/javascript-components.md
@@ -341,13 +341,11 @@ This library only currently supports the following polyfills:
 - `fs` - only implements `readFileSync` and `readdirSync`.
 - `os` - Implements only `EOL` and `arch`.
 
-
 ## Using External NPM Libraries
 
 > Not all the NPM packages are guaranteed to work with the SDK as it is not fully compatible with the browser or `Node.js`. It implements only a subset of the API.
 
 Some NPM packages can be installed and used in the component. If a popular library does not work, please open an issue/feature request in the [spin-js-sdk repository](https://github.com/spinframework/spin-js-sdk/issues).
-
 
 ### Suggested Libraries for Common Tasks
 

--- a/content/v3/key-value-store-tutorial.md
+++ b/content/v3/key-value-store-tutorial.md
@@ -147,7 +147,6 @@ key_value_stores = ["default"]
 ...
 ```
 
-
 ## Write Code to Save and Load Data
 
 In this section, we use the Spin SDK to open and persist our application's data inside our default key/value store. This is a special store that every environment running Spin applications will make available for their application. 
@@ -320,7 +319,6 @@ class IncomingHandler(http.IncomingHandler):
 ```
 
 {{ blockEnd }}
-
 
 {{ startTab "TinyGo" }}
 
@@ -523,4 +521,3 @@ Congratulations, you have a Spin application and associated Key Value store runn
 
 * Explore the contents of your Key Value store with the [Key Value Store Explorer template](../../hub/preview/template_kv_explorer)
 * Learn about linking your applications to different [Key Value Stores on Fermyon Cloud](../../cloud/kv-cloud-tutorial.md) 
-

--- a/content/v3/observing-apps.md
+++ b/content/v3/observing-apps.md
@@ -55,11 +55,11 @@ As your observability stack of choice is executed using traditional containers, 
 
 To see all available commands of the `otel` plugin, you can run `spin otel --help`.
 
-## Configuring your own observability stack
+## Configuring Your Own Observability Stack
 
 Follow this portion of the guide if you want to use Spin and OTel, but want to have more control than what the OTel plugin offers.
 
-### Configure the Docker compose stack
+### Configure the Docker Compose Stack
 
 In order to view the telemetry data you need to run an OTel compliant [collector](https://opentelemetry.io/docs/collector/) and the proper backends for each signal type. If you have Docker on your system you can easily start all the observability tools you need with the following commands:
 

--- a/content/v3/quickstart.md
+++ b/content/v3/quickstart.md
@@ -546,6 +546,7 @@ source = "app.wasm"
 [component.hello-python.build]
 command = "componentize-py -w spin-http componentize app -o app.wasm"
 ```
+
 This represents a simple Spin HTTP application (triggered by an HTTP request).  It has:
 
 * A single HTTP trigger, for the `/...` route, associated with the `hello-python` component.  `/...` is a wildcard, meaning it will match any route.  When the application gets an HTTP request that matches this route - that is, any HTTP request at all! - Spin will run the `hello-python` component.

--- a/content/v3/registry-tutorial.md
+++ b/content/v3/registry-tutorial.md
@@ -102,12 +102,11 @@ Lastly, let's run this Spin application:
 $ spin up -f ghcr.io/USERNAME/spin-react-fullstack:v1
 ```
 
-## Deploy a Spin App from GHCR (or any registry)
+## Deploy a Spin App From GHCR (or Any Registry)
 
 You can deploy a Spin app from any registry such as GHCR or DockerHub using the CLI command `spin deploy -f <remote-reference-here>` 
 
 > **Note:** You need a Fermyon Cloud account to deploy to. The remote-reference can be private, as long as you are authenticated locally to the registry in question, since the CLI will pull it down prior to publishing it to Cloud's internal registry.
-
 
 ## Conclusion
 

--- a/content/v3/rust-components.md
+++ b/content/v3/rust-components.md
@@ -523,7 +523,7 @@ annotated using the `http_component` macro, compiled to the `wasm32-wasip1` targ
 This means that any [crate](https://crates.io) that compiles to `wasm32-wasip1` can
 be used when implementing the component.
 
-### Using the `http` crate
+### Using the `http` Crate
 
 If you're already familiar with the popular [`http` crate](https://crates.io/crates/http), you may wish to use that instead of using the HTTP types included in the Spin SDK. Generally, the `http` crate's types can be used anywhere the Spin SDK HTTP types can be used. For example, the first basic HTTP component can be rewritten to use the `http` crate like so:
 

--- a/content/v3/see-what-people-have-built-with-spin.md
+++ b/content/v3/see-what-people-have-built-with-spin.md
@@ -19,7 +19,7 @@ url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v3/see-
 
 Spin can be used to build many different types of applications. The following blog articles show how different applications are built with Spin.
 
-## AI-powered bookmarking app with Python and WebAssembly
+## AI-Powered Bookmarking App with Python and WebAssembly
 
 [How to build an AI-powered bookmarking app with Python and WebAssembly](https://dev.to/fermyon/part-1-how-to-build-an-ai-powered-bookmarking-app-with-python-and-webassembly-2c5b).
 

--- a/content/v3/serverless-ai-api-guide.md
+++ b/content/v3/serverless-ai-api-guide.md
@@ -247,7 +247,7 @@ func init() {
 
 ## Troubleshooting
 
-### Error "Local LLM operations are not supported in this version of Spin"
+### Error "Local LLM Operations Are Not Supported in This Version of Spin"
 
 If you see "Local LLM operations are not supported in this version of Spin", then your copy of Spin has been built without local LLM support.
 

--- a/content/v3/serverless-ai-hello-world.md
+++ b/content/v3/serverless-ai-hello-world.md
@@ -63,7 +63,6 @@ python3 --version
 
 If you do not have Python 3.10 or later, you can install it by following the instructions [here](https://www.python.org/downloads/).
 
-
 To enable Serverless AI functionality via Python, please ensure you have the latest Python template installed:
 
 <!-- @selectiveCpy -->
@@ -345,7 +344,6 @@ class IncomingHandler(http.IncomingHandler):
             {"content-type": "text/plain"},
             bytes(res.text, "utf-8")
         )
-
 
 ```
  

--- a/content/v3/variables.md
+++ b/content/v3/variables.md
@@ -56,7 +56,6 @@ Variables can also be used in other sections of the application manifest that be
 allowed_outbound_hosts = [ "\{{ api_uri }}" ]
 ```
 
-
 All in all, an application manifest with `api_token` and `api_uri` variables and a component that uses them would look similar to the following:
 
 <!-- @nocpy -->

--- a/content/v3/writing-apps.md
+++ b/content/v3/writing-apps.md
@@ -456,7 +456,7 @@ During loading, Spin will download the package from the registry, locate its `se
 
 Spin supports three sources for dependencies.
 
-#### Dependencies from a Registry
+#### Dependencies From a Registry
 
 To use a dependency from a registry, specify the following fields:
 
@@ -474,7 +474,7 @@ If you don't need any of the optional fields, you can provide the version constr
 "security:http/malice" = "2.0.0"
 ```
 
-#### Dependencies from a Local Component
+#### Dependencies From a Local Component
 
 To use a dependency from a component on your file system, specify the following fields:
 
@@ -483,7 +483,7 @@ To use a dependency from a component on your file system, specify the following 
 | `path`     | Required    | The path to the Wasm file containing the component.                                          | `"../validation/request-checker.wasm"` |
 | `export`   | Optional    | The name of the export in the package. If omitted, this defaults to the name of the import.  | `"more-secure:checking-it-out/web"` |
 
-#### Dependencies from a URL
+#### Dependencies From a URL
 
 To use a dependency from an HTTP URL, such as a GitHub release, specify the following fields:
 
@@ -493,7 +493,7 @@ To use a dependency from an HTTP URL, such as a GitHub release, specify the foll
 | `digest`   | Required    | The SHA256 digest of the Wasm file. This is required for integrity checking.                 | `"sha256:650376c33a0756b1a52cad7ca670f1126391b79050df0321407da9c741d32375"` |
 | `export`   | Optional    | The name of the export in the package. If omitted, this defaults to the name of the import.  | `"more-secure:checking-it-out/web"` |
 
-### Mapping All Imports from a Package
+### Mapping All Imports From a Package
 
 If you are importing several interfaces from the same WIT package, and want them all satisfied by the same Wasm package, you can omit the interface from the dependency name. For example, suppose you import the `malice`, `tomfoolery`, and `shenanigans` WIT interfaces from the `security:http` package, and that your Bargain Security package exports all three of them.  You can write:
 

--- a/migration_scripts/README.md
+++ b/migration_scripts/README.md
@@ -71,7 +71,6 @@ python3 move_markdown_files_to_unified_location.py
 
 > If you are not satisfied with the outcome of this script, please run `./reset_content.sh` and try again.
 
-
 Check that no files are left over in either `/spin/v2` or `/cloud` directories (except for cloud changelog which should stay where it is).
 
 # Create redirects

--- a/migration_scripts/clean_up_after_migration.sh
+++ b/migration_scripts/clean_up_after_migration.sh
@@ -5,4 +5,3 @@ rm -rf ./spin_toml_backup.toml
 rm -rf mapping_information.xlsx
 rm -rf latest_sidebar.hbs
 
-

--- a/shortcodes/alert.rhai
+++ b/shortcodes/alert.rhai
@@ -1,7 +1,6 @@
 let type = params[0];
 let msg = params[1];
 
-
 let colors = #{
   primary:`alert-primary`,
   success:`alert-success`,
@@ -15,7 +14,6 @@ let icons = #{
   warning: `#exclamation-triangle-fill`,
   danger: `#exclamation-triangle-fill`,
 };
-
 
 `<svg xmlns="http://www.w3.org/2000/svg" style="display: none;">
   <symbol id="check-circle-fill" fill="currentColor" viewBox="0 0 16 16">

--- a/spin-up-hub/src/components/Card.vue
+++ b/spin-up-hub/src/components/Card.vue
@@ -74,7 +74,6 @@ export default {
   </div>
 </template>
 
-
 <style lang="scss" scoped>
 
 .card-image {
@@ -160,7 +159,6 @@ a.card {
                 opacity: 0.8;
             }
         }
-
 
         .icon {
             width: 20px;

--- a/spin-up-hub/src/components/ContentListing.vue
+++ b/spin-up-hub/src/components/ContentListing.vue
@@ -80,7 +80,6 @@ export default {
 }
 </script>
 
-
 <template>
     <div class="content-listing column is-four-fifths-desktop is-full-touch">
         <transition-group class="card-groups columns is-0 is-mobile is-multiline" tag="div"  name="card-list" appear>

--- a/spin-up-hub/src/components/DeployPreview.vue
+++ b/spin-up-hub/src/components/DeployPreview.vue
@@ -75,7 +75,6 @@ export default {
 }
 </script>
 
-
 <template>
   <div v-if="isOpen && !showCloudModalComponent" class="modal is-active">
     <div class="modal-background" @click="close"></div>
@@ -131,7 +130,6 @@ export default {
   </div>
   <CloudModal v-if="showCloudModalComponent" @close="hideCloudModal" />
 </template>
-
 
 <style lang="scss">
 .modal {
@@ -223,7 +221,6 @@ export default {
   margin-top: 0.6rem;
   margin-left: 40px;
 }
-
 
 .content-container {
   height: 100%;
@@ -393,7 +390,6 @@ a {
   height: auto;
   }
 }
-
 
 @media screen and (max-width: 1023px) {
   .box:not(.expanded) {

--- a/spin-up-hub/src/components/FermyonCloudModal.vue
+++ b/spin-up-hub/src/components/FermyonCloudModal.vue
@@ -367,4 +367,3 @@ html.dark-theme {
 </style>
 
 
-

--- a/spin-up-hub/src/components/HubIntro.vue
+++ b/spin-up-hub/src/components/HubIntro.vue
@@ -198,7 +198,6 @@ export default {
     background: linear-gradient(105deg, rgba(154, 103, 194, 0.21) 0%, rgba(124, 109, 185, 0.21) 100%);
     box-shadow: 0px 4px 4px 0px rgba(0, 0, 0, 0.25);
 
-
     h1.description {
       color: $thistle;
 

--- a/spin-up-hub/src/components/PreviewModal.vue
+++ b/spin-up-hub/src/components/PreviewModal.vue
@@ -1,7 +1,6 @@
 <script>
 import DeployModal from './DeployPreview.vue';
 
-
 export default {
     components: {
         DeployModal,
@@ -201,7 +200,6 @@ export default {
                 display: flex;
                 align-items: center;
                 justify-content: center;
-
 
                 &.icon-close {
                     right: 1.25rem;

--- a/static/js/src/modules/feedback.js
+++ b/static/js/src/modules/feedback.js
@@ -1,6 +1,5 @@
 const { el, mount, textContent, list, setChildren, setStyle, setAttr } = redom
 
-
 class FeedBack {
     constructor() {
         this.pageTitle = document.querySelector(".blog-post-title").innerText
@@ -116,7 +115,6 @@ class FeedBack {
         return false
     }
 }
-
 
 function createFeedbackElement(handle) {
     const feedback = new FeedBack()

--- a/static/js/src/modules/utils.js
+++ b/static/js/src/modules/utils.js
@@ -31,7 +31,6 @@ const svgCopy =
 const svgCheck =
     '<svg aria-hidden="true" height="24" viewBox="0 0 16 16" version="1.1" width="24" data-view-component="true"><path fill-rule="evenodd" fill="#18d1a5" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"></path></svg>';
 
-
 const addCopyButtons = (clipboard) => {
     document.querySelectorAll("pre > code").forEach((codeBlock) => {
         let content = codeBlock.innerText.trim()

--- a/static/sass/developer-color-dark.scss
+++ b/static/sass/developer-color-dark.scss
@@ -400,7 +400,6 @@ html.dark-theme {
 
 			}
 
-
 		}
 
 		.logo-wrap {

--- a/static/sass/developer-color.scss
+++ b/static/sass/developer-color.scss
@@ -2,7 +2,6 @@
 /* Styleguide Refresh from fermyon.com (1.5 design refresh)
 */
 
-
 $oxforddark: #0E092D;
 $vistablue: #8093F1;
 $lavenderfloral: #A87CE6;
@@ -17,7 +16,6 @@ $lavendermid: #E6D2F1;
 $lavenderlight: $thistle;
 $bluedark: #384687;
 $bluecallout: #282F55;
-
 
 //  fonts
 $spaceGro: 'Space Grotesk', Tofu, Sen, Europa, Avenir, system, -apple-system, SFNSText-Regular, San Francisco, Segoe UI, Helvetica Neue, Lucida Grande, sans-serif;

--- a/static/sass/developer-include-search.scss
+++ b/static/sass/developer-include-search.scss
@@ -131,7 +131,6 @@
 	}
 }
 
-
 .search-placeholder {
 	padding: 0 1rem 0 1rem;
 	font-weight: 600;
@@ -293,7 +292,6 @@
 		align-items: center;
 		line-height: 2;
 
-
 		.filter-categories {
 			max-width: 80%;
 
@@ -352,7 +350,6 @@
 				right: 0.75rem;
 				top: 0.375rem;
 			}
-
 
 			&:before {
 				transform: rotate(135deg);
@@ -447,7 +444,6 @@
 .result-item-icon {
 	padding: 0 0.5rem 0 0;
 }
-
 
 // dark search
 html.dark-theme {

--- a/static/sass/developer-include-sidebar.scss
+++ b/static/sass/developer-include-sidebar.scss
@@ -12,7 +12,6 @@
 }
 
 
-
 // sidebar width is fixed for desktop
 $sidebarWidth: 17.5vw;
 

--- a/static/sass/developer-include-topbar.scss
+++ b/static/sass/developer-include-topbar.scss
@@ -157,7 +157,6 @@
             display: inline-block;
             min-width: 10rem;
 
-
             strong, small {
                 display: block;
             }

--- a/static/sass/developer-responsive.scss
+++ b/static/sass/developer-responsive.scss
@@ -233,7 +233,6 @@
 		.content {
 			padding-top: 2rem;
 
-
 			h1 {
 				font-size: 6.333vw;
 			}
@@ -292,7 +291,6 @@
         }
     }
 }
-
 
 // desktop
 @media screen and (max-width: 1660px) {
@@ -391,7 +389,6 @@
     }
 }
 
-
 // medium desktops
 @media screen and (min-width: 1381px) and (max-width: 1439px) {
     #topbar.navbar {
@@ -406,7 +403,6 @@
         }
     }
 }
-
 
 // wide desktops
 @media screen and (min-width: 1660px) {

--- a/static/sass/styles.scss
+++ b/static/sass/styles.scss
@@ -31,7 +31,6 @@ $lavenderlight: $thistle;
 $bluedark: #384687;
 $bluecallout: #282F55;
 
-
 /* 1.2 Developer Styles
 */
 .documentation {
@@ -73,7 +72,6 @@ $bluecallout: #282F55;
 		section {
 			margin-left: auto !important;
 			margin-right: auto !important;
-
 
 			// toc
 			h1:first-of-type+ul {
@@ -599,7 +597,6 @@ https://github.com/kiprotect/klaro */
 		color: white;
 	}
 }
-
 
 @media print {
 

--- a/templates/404.hbs
+++ b/templates/404.hbs
@@ -1,4 +1,3 @@
 <h1 class="blog-post-title border-bottom">The page does not exist!</h1>
 
-
 <p> Find your way back to the <a href="/">homepage</a> or the <a href="/spin">Spin docs</a> or the <a href="/cloud"> Fermyon Cloud docs</a></p>

--- a/templates/content_top.hbs
+++ b/templates/content_top.hbs
@@ -106,7 +106,6 @@
             setTheme(localStorage.getItem("theme"));
         };
 
-
         function setTheme(mode) {
             localStorage.setItem("theme", mode);
             savedTheme = mode;

--- a/templates/main.hbs
+++ b/templates/main.hbs
@@ -35,7 +35,6 @@
     </div>
 </main>
 
-
 {{! This closes the body. See content_bottom.hbs. }}
 {{> content_bottom }}
 

--- a/templates/sidebar.hbs
+++ b/templates/sidebar.hbs
@@ -86,7 +86,6 @@
 
         
 
-
     <div class="accordion-menu-item" style="display: none;">
         <input type="checkbox" id="rd5" name="rd">
         <label for="rd5" class="accordion-menu-item-label menu-label">


### PR DESCRIPTION
Starting to fill out the GH workflows, here adding the build workflow.

Addresses a bunch of lint-like errors from `npm run test`, but broken links may still remain per https://github.com/spinframework/spin-docs/issues/12.

We can either merge now/as-is and expect failing builds (but just not block on them) or block this PR on all fixes