### PR TITLE
ci(.github): add deploy preview workflow

### DIFF
--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -1,0 +1,37 @@
+name: deploy docs preview
+on:
+  pull_request:
+    branches: "main"
+    types: ['opened', 'synchronize', 'reopened', 'closed']
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-24.04
+    if: ${{ !github.event.pull_request.head.repo.fork }}
+    name: Build and deploy
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup `spin`
+        uses: fermyon/actions/spin/setup@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install npm packages
+        run: |
+          npm ci
+          npm ci --prefix ./spin-up-hub
+
+      - name: Build app
+        run: |
+          spin build
+
+      - name: build and deploy preview
+        uses: fermyon/actions/spin/preview@v1
+        env:
+          # Create archive layers to consolidate the hundreds of static asset layers together
+          SPIN_OCI_ARCHIVE_LAYERS: 1
+        with:
+          fermyon_token: ${{ secrets.FERMYON_CLOUD_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          undeploy: ${{ github.event.pull_request && github.event.action == 'closed' }}


### PR DESCRIPTION
- Adds the deploy preview workflow to get PR previews
- I added SPIN_OCI_ARCHIVE_LAYERS (and comment) because this appeared to be needed when deploying locally; I haven't pinpointed the cause of intermittent unsuccessful deploys without it, but I suspect it's something to do with the massive amount of layers otherwise and perhaps concurrent uploads.