### PR TITLE
docs(*): s^content/spin/^content/^g

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v3/index.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v3/index.md"
 
 ---
 

--- a/content/v1/ai-sentiment-analysis-api-tutorial.md
+++ b/content/v1/ai-sentiment-analysis-api-tutorial.md
@@ -4,7 +4,7 @@ date = "2023-09-05T09:00:00Z"
 enable_shortcodes = true
 [extra]
 canonical_url = "https://spinframework.dev/v2/ai-sentiment-analysis-api-tutorial"
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v1/ai-sentiment-analysis-api-tutorial.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v1/ai-sentiment-analysis-api-tutorial.md"
 
 ---
 - [Tutorial Prerequisites](#tutorial-prerequisites)

--- a/content/v1/api-guides-overview.md
+++ b/content/v1/api-guides-overview.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-03-03T03:03:03Z"
 [extra]
 canonical_url = "https://spinframework.dev/v2/api-guides-overview"
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v1/api-guides-overview.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v1/api-guides-overview.md"
 
 ---
 

--- a/content/v1/build.md
+++ b/content/v1/build.md
@@ -4,7 +4,7 @@ date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
 canonical_url = "https://spinframework.dev/v2/build"
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v1/build.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v1/build.md"
 
 ---
 

--- a/content/v1/cache.md
+++ b/content/v1/cache.md
@@ -4,7 +4,7 @@ date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
 canonical_url = "https://spinframework.dev/v2/cache"
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v1/cache.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v1/cache.md"
 
 ---
 

--- a/content/v1/cli-reference.md
+++ b/content/v1/cli-reference.md
@@ -4,7 +4,7 @@ date = "2022-01-01T00:00:01Z"
 enable_shortcodes = true
 [extra]
 canonical_url = "https://spinframework.dev/v2/cli-reference"
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v1/cli-reference.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v1/cli-reference.md"
 
 ---
 - [spin add](#spin-add)

--- a/content/v1/contributing-docs.md
+++ b/content/v1/contributing-docs.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2022-01-01T00:00:01Z"
 [extra]
 canonical_url = "https://spinframework.dev/v2/contributing-docs"
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v1/contributing-docs.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v1/contributing-docs.md"
 keywords = "contribute contributing"
 
 ---
@@ -248,9 +248,9 @@ $ npm run test
 
 ```bash
 # Example of how to lint all Markdown files in a local folder (in this case the spin folder) 
-npx markdownlint-cli2 content/spin/*.md \"#node_modules\"
+npx markdownlint-cli2 content/*.md \"#node_modules\"
 # Example of how to lint a local Markdown file
-npx markdownlint-cli2 content/spin/install.md \"#node_modules\"
+npx markdownlint-cli2 content/install.md \"#node_modules\"
 ```
 
 **Note:** Whilst the `npm run test` command (which lints and also programmatically checks all URLs) does take extra time to complete it **must** be utilized before you [push changes](#10-push-changes); preventing the potential pushing of broken URLs to the documentation site.
@@ -304,7 +304,7 @@ If you create a new markdown file and/or you notice a file without the explicit 
 
 ```
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v1/contributing-docs.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v1/contributing-docs.md"
 ```
 
 ### 6.5 How To Properly Edit CSS Styles
@@ -393,16 +393,16 @@ The `bart check` command can be used to check the content. Simply pass in the co
 <!-- @selectiveCpy -->
 
 ```bash
-$ bart check --shortcodes ./shortcodes content/spin/variables.md
+$ bart check --shortcodes ./shortcodes content/variables.md
 shortcodes: registering alert
 shortcodes: registering details
 shortcodes: registering tabs
 shortcodes: registering startTab
 shortcodes: registering blockEnd
-✅ content/spin/variables.md
+✅ content/variables.md
 ```
 
-> Note: `using a wildcard `*` will check a whole directory via a single command. For example, running `bart check --shortcodes ./shortcodes content/spin/*` will check all markdown files in the Spin project's documentation section.
+> Note: `using a wildcard `*` will check a whole directory via a single command. For example, running `bart check --shortcodes ./shortcodes content/*` will check all markdown files in the Spin project's documentation section.
 
 ### 8. Add Changes
 

--- a/content/v1/contributing-spin.md
+++ b/content/v1/contributing-spin.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2022-03-14T00:22:56Z"
 [extra]
 canonical_url = "https://spinframework.dev/v3/contributing-spin"
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v3/contributing-spin.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v3/contributing-spin.md"
 
 ---
 - [Making Code Contributions to Spin](#making-code-contributions-to-spin)

--- a/content/v1/distributing-apps.md
+++ b/content/v1/distributing-apps.md
@@ -4,7 +4,7 @@ date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
 canonical_url = "https://spinframework.dev/v2/distributing-apps"
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v1/distributing-apps.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v1/distributing-apps.md"
 
 ---
 - [Logging Into a Registry](#logging-into-a-registry)

--- a/content/v1/dynamic-configuration.md
+++ b/content/v1/dynamic-configuration.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2022-03-14T00:22:56Z"
 [extra]
 canonical_url = "https://spinframework.dev/v2/dynamic-configuration"
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v1/dynamic-configuration.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v1/dynamic-configuration.md"
 
 ---
 - [Application Variables Runtime Configuration](#application-variables-runtime-configuration)

--- a/content/v1/extending-and-embedding.md
+++ b/content/v1/extending-and-embedding.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2022-03-14T00:22:56Z"
 [extra]
 canonical_url = "https://spinframework.dev/v2/extending-and-embedding"
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v1/extending-and-embedding.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v1/extending-and-embedding.md"
 
 ---
 - [Other Ways to Extend and Use Spin](#other-ways-to-extend-and-use-spin)

--- a/content/v1/go-components.md
+++ b/content/v1/go-components.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2022-03-14T00:22:56Z"
 [extra]
 canonical_url = "https://spinframework.dev/v2/go-components"
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v1/go-components.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v1/go-components.md"
 
 ---
 

--- a/content/v1/http-outbound.md
+++ b/content/v1/http-outbound.md
@@ -4,7 +4,7 @@ date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
 canonical_url = "https://spinframework.dev/v2/http-outbound"
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v1/http-outbound.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v1/http-outbound.md"
 
 ---
 - [Using HTTP From Applications](#using-http-from-applications)

--- a/content/v1/http-trigger.md
+++ b/content/v1/http-trigger.md
@@ -4,7 +4,7 @@ date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
 canonical_url = "https://spinframework.dev/v2/http-trigger"
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v1/http-trigger.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v1/http-trigger.md"
 
 ---
 - [Specifying an Application as HTTP](#specifying-an-application-as-http)

--- a/content/v1/index.md
+++ b/content/v1/index.md
@@ -4,7 +4,7 @@ date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
 canonical_url = "https://spinframework.dev/v2/index"
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v1/index.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v1/index.md"
 
 
 ---

--- a/content/v1/install.md
+++ b/content/v1/install.md
@@ -4,7 +4,7 @@ date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
 canonical_url = "https://spinframework.dev/v2/install"
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v1/install.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v1/install.md"
 keywords = "install"
 
 ---

--- a/content/v1/javascript-components.md
+++ b/content/v1/javascript-components.md
@@ -4,7 +4,7 @@ date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
 canonical_url = "https://spinframework.dev/v2/javascript-components"
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v1/javascript-components.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v1/javascript-components.md"
 
 ---
 - [Installing Templates](#installing-templates)

--- a/content/v1/key-value-store-tutorial.md
+++ b/content/v1/key-value-store-tutorial.md
@@ -4,7 +4,7 @@ date = "2023-02-21T00:00:00Z"
 enable_shortcodes = true
 [extra]
 canonical_url = "https://spinframework.dev/v2/key-value-store-tutorial"
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v1/key-value-store-tutorial.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v1/key-value-store-tutorial.md"
 
 ---
 - [Key Value Store With Spin Applications](#key-value-store-with-spin-applications)

--- a/content/v1/kubernetes.md
+++ b/content/v1/kubernetes.md
@@ -4,7 +4,7 @@ date = "2023-03-01T00:01:01Z"
 enable_shortcodes = true
 [extra]
 canonical_url = "https://spinframework.dev/v2/kubernetes"
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v1/kubernetes.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v1/kubernetes.md"
 
 ---
 - [Why Use Spin With Kubernetes?](#why-use-spin-with-kubernetes)

--- a/content/v1/kv-store-api-guide.md
+++ b/content/v1/kv-store-api-guide.md
@@ -4,7 +4,7 @@ date = "2023-04-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
 canonical_url = "https://spinframework.dev/v2/kv-store-api-guide"
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v1/kv-store-api-guide.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v1/kv-store-api-guide.md"
 
 ---
 - [Using Key Value Store From Applications](#using-key-value-store-from-applications)

--- a/content/v1/language-support-overview.md
+++ b/content/v1/language-support-overview.md
@@ -4,7 +4,7 @@ date = "2022-01-01T00:00:01Z"
 enable_shortcodes = true
 [extra]
 canonical_url = "https://spinframework.dev/v2/language-support-overview"
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v1/language-support-overview.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v1/language-support-overview.md"
 
 ---
 

--- a/content/v1/managing-plugins.md
+++ b/content/v1/managing-plugins.md
@@ -4,7 +4,7 @@ date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
 canonical_url = "https://spinframework.dev/v2/managing-plugins"
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v1/managing-plugins.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v1/managing-plugins.md"
 
 ---
 - [Installing Plugins](#installing-plugins)

--- a/content/v1/managing-templates.md
+++ b/content/v1/managing-templates.md
@@ -4,7 +4,7 @@ date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
 canonical_url = "https://spinframework.dev/v2/managing-templates"
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v1/managing-templates.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v1/managing-templates.md"
 
 ---
 - [Installing Templates](#installing-templates)

--- a/content/v1/manifest-reference.md
+++ b/content/v1/manifest-reference.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2022-03-14T00:22:56Z"
 [extra]
 canonical_url = "https://spinframework.dev/v2/manifest-reference"
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v1/manifest-reference.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v1/manifest-reference.md"
 
 ---
 - [Format](#format)

--- a/content/v1/other-languages.md
+++ b/content/v1/other-languages.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2022-03-14T00:22:56Z"
 [extra]
 canonical_url = "https://spinframework.dev/v2/other-languages"
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v1/other-languages.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v1/other-languages.md"
 
 ---
 - [AssemblyScript](#assemblyscript)

--- a/content/v1/plugin-authoring.md
+++ b/content/v1/plugin-authoring.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-02-1T00:22:56Z"
 [extra]
 canonical_url = "https://spinframework.dev/v2/plugin-authoring"
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v1/plugin-authoring.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v1/plugin-authoring.md"
 
 ---
 - [What Are Spin Plugins?](#what-are-spin-plugins)

--- a/content/v1/python-components.md
+++ b/content/v1/python-components.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-02-28T02:00:00Z"
 [extra]
 canonical_url = "https://spinframework.dev/v2/python-components"
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v1/python-components.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v1/python-components.md"
 
 ---
 - [Spin's Python Plugin](#spins-python-plugin)

--- a/content/v1/quickstart.md
+++ b/content/v1/quickstart.md
@@ -4,7 +4,7 @@ date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
 canonical_url = "https://spinframework.dev/v2/quickstart"
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v1/quickstart.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v1/quickstart.md"
 keywords = "quickstart"
 
 ---

--- a/content/v1/rdbms-storage.md
+++ b/content/v1/rdbms-storage.md
@@ -4,7 +4,7 @@ date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
 canonical_url = "https://spinframework.dev/v2/rdbms-storage"
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v1/rdbms-storage.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v1/rdbms-storage.md"
 
 ---
 - [Using MySQL and PostgreSQL From Applications](#using-mysql-and-postgresql-from-applications)

--- a/content/v1/redis-outbound.md
+++ b/content/v1/redis-outbound.md
@@ -4,7 +4,7 @@ date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
 canonical_url = "https://spinframework.dev/v2/redis-outbound"
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v1/redis-outbound.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v1/redis-outbound.md"
 
 ---
 - [Using Redis From Applications](#using-redis-from-applications)

--- a/content/v1/redis-trigger.md
+++ b/content/v1/redis-trigger.md
@@ -4,7 +4,7 @@ date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
 canonical_url = "https://spinframework.dev/v2/redis-trigger"
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v1/redis-trigger.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v1/redis-trigger.md"
 
 ---
 - [Specifying an Application as Redis](#specifying-an-application-as-redis)

--- a/content/v1/registry-tutorial.md
+++ b/content/v1/registry-tutorial.md
@@ -4,7 +4,7 @@ date = "2023-02-13T00:00:00Z"
 enable_shortcodes = true
 [extra]
 canonical_url = "https://spinframework.dev/v2/registry-tutorial"
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v1/registry-tutorial.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v1/registry-tutorial.md"
 
 ---
 - [Spin Registry Support](#spin-registry-support)

--- a/content/v1/running-apps.md
+++ b/content/v1/running-apps.md
@@ -4,7 +4,7 @@ date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
 canonical_url = "https://spinframework.dev/v2/running-apps"
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v1/running-apps.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v1/running-apps.md"
 
 ---
 - [Specifying the Application to Run](#specifying-the-application-to-run)

--- a/content/v1/rust-components.md
+++ b/content/v1/rust-components.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2022-03-14T00:22:56Z"
 [extra]
 canonical_url = "https://spinframework.dev/v2/rust-components"
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v1/rust-components.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v1/rust-components.md"
 
 ---
 - [Prerequisites](#prerequisites)

--- a/content/v1/see-what-people-have-built-with-spin.md
+++ b/content/v1/see-what-people-have-built-with-spin.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-05-05T00:01:01Z"
 [extra]
 canonical_url = "https://spinframework.dev/v2/see-what-people-have-built-with-spin"
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v1/see-what-people-have-built-with-spin.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v1/see-what-people-have-built-with-spin.md"
 
 ---
 - [Like Button](#like-button)

--- a/content/v1/serverless-ai-api-guide.md
+++ b/content/v1/serverless-ai-api-guide.md
@@ -4,7 +4,7 @@ date = "2023-09-05T09:00:00Z"
 enable_shortcodes = true
 [extra]
 canonical_url = "https://spinframework.dev/v2/serverless-ai-api-guide"
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v1/serverless-ai-api-guide.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v1/serverless-ai-api-guide.md"
 
 ---
 - [Using Serverless AI From Applications](#using-serverless-ai-from-applications)

--- a/content/v1/serverless-ai-hello-world.md
+++ b/content/v1/serverless-ai-hello-world.md
@@ -6,7 +6,7 @@ tags = ["ai", "serverless", "getting started"]
 enable_shortcodes = true
 [extra]
 canonical_url = "https://spinframework.dev/v2/serverless-ai-hello-world"
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v1/serverless-ai-hello-world.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v1/serverless-ai-hello-world.md"
 
 ---
 

--- a/content/v1/spin-application-structure.md
+++ b/content/v1/spin-application-structure.md
@@ -4,7 +4,7 @@ date = "2023-08-20T00:00:00Z"
 enable_shortcodes = true
 [extra]
 canonical_url = "https://spinframework.dev/v2/spin-application-structure"
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v1/spin-application-structure.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v1/spin-application-structure.md"
 keywords = "structure"
 
 ---

--- a/content/v1/sqlite-api-guide.md
+++ b/content/v1/sqlite-api-guide.md
@@ -4,7 +4,7 @@ date = "2023-04-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
 canonical_url = "https://spinframework.dev/v2/sqlite-api-guide"
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v1/sqlite-api-guide.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v1/sqlite-api-guide.md"
 
 ---
 - [Granting SQLite Database Permissions to Components](#granting-sqlite-database-permissions-to-components)

--- a/content/v1/template-authoring.md
+++ b/content/v1/template-authoring.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2022-03-14T00:22:56Z"
 [extra]
 canonical_url = "https://spinframework.dev/v2/template-authoring"
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v1/template-authoring.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v1/template-authoring.md"
 
 ---
 - [Authoring the Content](#authoring-the-content)

--- a/content/v1/troubleshooting-application-dev.md
+++ b/content/v1/troubleshooting-application-dev.md
@@ -4,7 +4,7 @@ date = "2023-02-13T00:00:00Z"
 enable_shortcodes = true
 [extra]
 canonical_url = "https://spinframework.dev/v2/troubleshooting-application-dev"
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v1/troubleshooting-application-dev.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v1/troubleshooting-application-dev.md"
 
 ---
 

--- a/content/v1/upgrade.md
+++ b/content/v1/upgrade.md
@@ -4,7 +4,7 @@ date = "2023-05-01T00:01:01Z"
 enable_shortcodes = true
 [extra]
 canonical_url = "https://spinframework.dev/v2/upgrade"
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v1/upgrade.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v1/upgrade.md"
 
 ---
 - [Are You on the Latest Version?](#are-you-on-the-latest-version)

--- a/content/v1/url-shortener-tutorial.md
+++ b/content/v1/url-shortener-tutorial.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2022-03-14T00:22:56Z"
 [extra]
 canonical_url = "https://spinframework.dev/v2/url-shortener-tutorial"
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v1/url-shortener-tutorial.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v1/url-shortener-tutorial.md"
 
 ---
 - [A Simple URL Shortener Built With Spin](#a-simple-url-shortener-built-with-spin)

--- a/content/v1/variables.md
+++ b/content/v1/variables.md
@@ -4,7 +4,7 @@ date = "2022-06-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
 canonical_url = "https://spinframework.dev/v2/variables"
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v1/variables.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v1/variables.md"
 
 ---
 - [Adding Variables to Your Applications](#adding-variables-to-your-applications)

--- a/content/v1/writing-apps.md
+++ b/content/v1/writing-apps.md
@@ -4,7 +4,7 @@ date = "2022-03-14T00:22:56Z"
 enable_shortcodes = true
 [extra]
 canonical_url = "https://spinframework.dev/v2/writing-apps"
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v1/writing-apps.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v1/writing-apps.md"
 
 ---
 - [Writing an Application Manifest](#writing-an-application-manifest)

--- a/content/v2/ai-sentiment-analysis-api-tutorial.md
+++ b/content/v2/ai-sentiment-analysis-api-tutorial.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v2/ai-sentiment-analysis-api-tutorial.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v2/ai-sentiment-analysis-api-tutorial.md"
 
 ---
 - [Tutorial Prerequisites](#tutorial-prerequisites)

--- a/content/v2/api-guides-overview.md
+++ b/content/v2/api-guides-overview.md
@@ -2,7 +2,7 @@ title = "API Support Overview"
 template = "main"
 date = "2023-11-04T00:00:01Z"
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v2/api-guides-overview.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v2/api-guides-overview.md"
 
 ---
 

--- a/content/v2/build.md
+++ b/content/v2/build.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v2/build.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v2/build.md"
 
 ---
 

--- a/content/v2/cache.md
+++ b/content/v2/cache.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v2/cache.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v2/cache.md"
 
 ---
 

--- a/content/v2/cli-reference.md
+++ b/content/v2/cli-reference.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v2/cli-reference.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v2/cli-reference.md"
 
 ---
 - [spin add](#spin-add)

--- a/content/v2/contributing-docs.md
+++ b/content/v2/contributing-docs.md
@@ -2,7 +2,7 @@ title = "Contributing to Docs"
 template = "main"
 date = "2023-11-04T00:00:01Z"
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v2/contributing-docs.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v2/contributing-docs.md"
 keywords = "contribute contributing"
 
 ---
@@ -276,9 +276,9 @@ $ npm run test
 
 ```bash
 # Example of how to lint all Markdown files in a local folder (in this case the spin folder) 
-npx markdownlint-cli2 content/spin/*.md \"#node_modules\"
+npx markdownlint-cli2 content/*.md \"#node_modules\"
 # Example of how to lint a local Markdown file
-npx markdownlint-cli2 content/spin/install.md \"#node_modules\"
+npx markdownlint-cli2 content/install.md \"#node_modules\"
 ```
 
 **Note:** Whilst the `npm run test` command (which lints and also programmatically checks all URLs) does take extra time to complete it **must** be utilized before you [push changes](#10-push-changes); preventing the potential pushing of broken URLs to the documentation site.
@@ -332,7 +332,7 @@ If you create a new markdown file and/or you notice a file without the explicit 
 
 ```
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v2/contributing-docs.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v2/contributing-docs.md"
 ```
 
 ### 6.5 How To Properly Edit CSS Styles
@@ -435,16 +435,16 @@ The `bart check` command can be used to check the content. Simply pass in the co
 <!-- @selectiveCpy -->
 
 ```bash
-$ bart check --shortcodes ./shortcodes content/spin/variables.md
+$ bart check --shortcodes ./shortcodes content/variables.md
 shortcodes: registering alert
 shortcodes: registering details
 shortcodes: registering tabs
 shortcodes: registering startTab
 shortcodes: registering blockEnd
-✅ content/spin/variables.md
+✅ content/variables.md
 ```
 
-> Note: `using a wildcard `*` will check a whole directory via a single command. For example, running `bart check --shortcodes ./shortcodes content/spin/*` will check all markdown files in the Spin project's documentation section.
+> Note: `using a wildcard `*` will check a whole directory via a single command. For example, running `bart check --shortcodes ./shortcodes content/*` will check all markdown files in the Spin project's documentation section.
 
 ### 8. Add Changes
 

--- a/content/v2/contributing-spin.md
+++ b/content/v2/contributing-spin.md
@@ -2,7 +2,7 @@ title = "Contributing to Spin"
 template = "main"
 date = "2023-11-04T00:00:01Z"
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v2/contributing-spin.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v2/contributing-spin.md"
 
 ---
 - [Making Code Contributions to Spin](#making-code-contributions-to-spin)

--- a/content/v2/deploying-to-fermyon.md
+++ b/content/v2/deploying-to-fermyon.md
@@ -2,7 +2,7 @@ title = "Deploying Spin Applications to Fermyon"
 template = "main"
 date = "2023-11-04T00:00:01Z"
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v2/deploying-to-fermyon.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v2/deploying-to-fermyon.md"
 
 ---
 - [Fermyon Cloud](#fermyon-cloud)

--- a/content/v2/distributing-apps.md
+++ b/content/v2/distributing-apps.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v2/distributing-apps.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v2/distributing-apps.md"
 
 ---
 - [Logging Into a Registry](#logging-into-a-registry)

--- a/content/v2/dynamic-configuration.md
+++ b/content/v2/dynamic-configuration.md
@@ -2,7 +2,7 @@ title = "Dynamic and Runtime Application Configuration"
 template = "main"
 date = "2023-11-04T00:00:01Z"
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v2/dynamic-configuration.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v2/dynamic-configuration.md"
 
 ---
 

--- a/content/v2/extending-and-embedding.md
+++ b/content/v2/extending-and-embedding.md
@@ -2,7 +2,7 @@ title = "Extending and Embedding Spin"
 template = "main"
 date = "2023-11-04T00:00:01Z"
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v2/extending-and-embedding.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v2/extending-and-embedding.md"
 
 ---
 - [Extending Spin with a Custom Trigger](#extending-spin-with-a-custom-trigger)

--- a/content/v2/go-components.md
+++ b/content/v2/go-components.md
@@ -2,7 +2,7 @@ title = "Building Spin components in Go"
 template = "main"
 date = "2023-11-04T00:00:01Z"
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v2/go-components.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v2/go-components.md"
 
 ---
 

--- a/content/v2/http-outbound.md
+++ b/content/v2/http-outbound.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v2/http-outbound.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v2/http-outbound.md"
 
 ---
 - [Using HTTP From Applications](#using-http-from-applications)

--- a/content/v2/http-trigger.md
+++ b/content/v2/http-trigger.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v2/http-trigger.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v2/http-trigger.md"
 
 ---
 - [Specifying an HTTP Trigger](#specifying-an-http-trigger)

--- a/content/v2/index.md
+++ b/content/v2/index.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v2/index.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v2/index.md"
 
 ---
 

--- a/content/v2/install.md
+++ b/content/v2/install.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v2/install.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v2/install.md"
 keywords = "install"
 
 ---

--- a/content/v2/javascript-components.md
+++ b/content/v2/javascript-components.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v2/javascript-components.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v2/javascript-components.md"
 
 ---
 - [Installing Templates](#installing-templates)

--- a/content/v2/key-value-store-tutorial.md
+++ b/content/v2/key-value-store-tutorial.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v2/key-value-store-tutorial.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v2/key-value-store-tutorial.md"
 
 ---
 - [Key Value Store With Spin Applications](#key-value-store-with-spin-applications)

--- a/content/v2/kubernetes.md
+++ b/content/v2/kubernetes.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2024-03-07T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v2/kubernetes.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v2/kubernetes.md"
 
 ---
 

--- a/content/v2/kv-store-api-guide.md
+++ b/content/v2/kv-store-api-guide.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v2/kv-store-api-guide.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v2/kv-store-api-guide.md"
 
 ---
 - [Using Key Value Store From Applications](#using-key-value-store-from-applications)

--- a/content/v2/language-support-overview.md
+++ b/content/v2/language-support-overview.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v2/language-support-overview.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v2/language-support-overview.md"
 
 ---
 

--- a/content/v2/managing-plugins.md
+++ b/content/v2/managing-plugins.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v2/managing-plugins.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v2/managing-plugins.md"
 
 ---
 - [Installing Plugins](#installing-plugins)

--- a/content/v2/managing-templates.md
+++ b/content/v2/managing-templates.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v2/managing-templates.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v2/managing-templates.md"
 
 ---
 - [Installing Templates](#installing-templates)

--- a/content/v2/manifest-reference-v1.md
+++ b/content/v2/manifest-reference-v1.md
@@ -2,7 +2,7 @@ title = "Spin Application Manifest (Version 1) Reference"
 template = "main"
 date = "2023-11-04T00:00:01Z"
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v2/manifest-reference-v1.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v2/manifest-reference-v1.md"
 
 ---
 - [Format](#format)

--- a/content/v2/manifest-reference.md
+++ b/content/v2/manifest-reference.md
@@ -2,7 +2,7 @@ title = "Spin Application Manifest Reference"
 template = "main"
 date = "2023-11-04T00:00:01Z"
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v2/manifest-reference.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v2/manifest-reference.md"
 
 ---
 - [Manifest Format](#manifest-format)

--- a/content/v2/mqtt-outbound.md
+++ b/content/v2/mqtt-outbound.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v2/mqtt-outbound.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v2/mqtt-outbound.md"
 
 ---
 - [Sending MQTT Messages From Applications](#sending-mqtt-messages-from-applications)

--- a/content/v2/observing-apps.md
+++ b/content/v2/observing-apps.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v2/observing-apps.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v2/observing-apps.md"
 
 ---
 

--- a/content/v2/other-languages.md
+++ b/content/v2/other-languages.md
@@ -2,7 +2,7 @@ title = "Building Spin components in other languages"
 template = "main"
 date = "2023-11-04T00:00:01Z"
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v2/other-languages.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v2/other-languages.md"
 
 ---
 - [C/C++](#cc)

--- a/content/v2/plugin-authoring.md
+++ b/content/v2/plugin-authoring.md
@@ -2,7 +2,7 @@ title = "Creating Spin Plugins"
 template = "main"
 date = "2023-11-04T00:00:01Z"
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v2/plugin-authoring.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v2/plugin-authoring.md"
 
 ---
 - [What Are Spin Plugins?](#what-are-spin-plugins)

--- a/content/v2/python-components.md
+++ b/content/v2/python-components.md
@@ -2,7 +2,7 @@ title = "Building Spin Components in Python"
 template = "main"
 date = "2023-11-04T00:00:01Z"
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v2/python-components.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v2/python-components.md"
 
 ---
 - [Prerequisite](#prerequisite)

--- a/content/v2/quickstart.md
+++ b/content/v2/quickstart.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v2/quickstart.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v2/quickstart.md"
 keywords = "quickstart"
 
 ---

--- a/content/v2/rdbms-storage.md
+++ b/content/v2/rdbms-storage.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v2/rdbms-storage.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v2/rdbms-storage.md"
 
 ---
 - [Using MySQL and PostgreSQL From Applications](#using-mysql-and-postgresql-from-applications)

--- a/content/v2/redis-outbound.md
+++ b/content/v2/redis-outbound.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v2/redis-outbound.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v2/redis-outbound.md"
 
 ---
 - [Using Redis From Applications](#using-redis-from-applications)

--- a/content/v2/redis-trigger.md
+++ b/content/v2/redis-trigger.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v2/redis-trigger.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v2/redis-trigger.md"
 
 ---
 - [Specifying a Redis Trigger](#specifying-a-redis-trigger)

--- a/content/v2/registry-tutorial.md
+++ b/content/v2/registry-tutorial.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v2/registry-tutorial.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v2/registry-tutorial.md"
 
 ---
 - [Spin Registry Support](#spin-registry-support)

--- a/content/v2/running-apps.md
+++ b/content/v2/running-apps.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v2/running-apps.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v2/running-apps.md"
 
 ---
 - [Specifying the Application to Run](#specifying-the-application-to-run)

--- a/content/v2/rust-components.md
+++ b/content/v2/rust-components.md
@@ -2,7 +2,7 @@ title = "Building Spin components in Rust"
 template = "main"
 date = "2023-11-04T00:00:01Z"
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v2/rust-components.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v2/rust-components.md"
 
 ---
 - [Prerequisites](#prerequisites)

--- a/content/v2/see-what-people-have-built-with-spin.md
+++ b/content/v2/see-what-people-have-built-with-spin.md
@@ -2,7 +2,7 @@ title = "Built With Spin"
 template = "main"
 date = "2023-11-04T00:00:01Z"
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v2/see-what-people-have-built-with-spin.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v2/see-what-people-have-built-with-spin.md"
 
 ---
 - [AI-powered bookmarking app with Python and WebAssembly](#ai-powered-bookmarking-app-with-python-and-webassembly)

--- a/content/v2/serverless-ai-api-guide.md
+++ b/content/v2/serverless-ai-api-guide.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v2/serverless-ai-api-guide.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v2/serverless-ai-api-guide.md"
 
 ---
 - [Using Serverless AI From Applications](#using-serverless-ai-from-applications)

--- a/content/v2/serverless-ai-hello-world.md
+++ b/content/v2/serverless-ai-hello-world.md
@@ -5,7 +5,7 @@ template = "main"
 tags = ["ai", "serverless", "getting started"]
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v2/serverless-ai-hello-world.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v2/serverless-ai-hello-world.md"
 
 ---
 

--- a/content/v2/spin-application-structure.md
+++ b/content/v2/spin-application-structure.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v2/spin-application-structure.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v2/spin-application-structure.md"
 keywords = "structure"
 
 ---

--- a/content/v2/spin-in-pods-legacy.md
+++ b/content/v2/spin-in-pods-legacy.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v2/spin-in-pods-legacy.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v2/spin-in-pods-legacy.md"
 
 ---
 

--- a/content/v2/sqlite-api-guide.md
+++ b/content/v2/sqlite-api-guide.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v2/sqlite-api-guide.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v2/sqlite-api-guide.md"
 
 ---
 - [Granting SQLite Database Permissions to Components](#granting-sqlite-database-permissions-to-components)

--- a/content/v2/template-authoring.md
+++ b/content/v2/template-authoring.md
@@ -2,7 +2,7 @@ title = "Creating Spin templates"
 template = "main"
 date = "2023-11-04T00:00:01Z"
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v2/template-authoring.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v2/template-authoring.md"
 
 ---
 - [Authoring the Content](#authoring-the-content)

--- a/content/v2/testing-apps.md
+++ b/content/v2/testing-apps.md
@@ -2,7 +2,7 @@ title = "Testing Applications"
 template = "main"
 date = "2024-05-05T00:00:01Z"
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v2/testing-apps.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v2/testing-apps.md"
 
 ---
 

--- a/content/v2/triggers.md
+++ b/content/v2/triggers.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v2/triggers.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v2/triggers.md"
 
 ---
 - [Triggers and Components](#triggers-and-components)

--- a/content/v2/troubleshooting-application-dev.md
+++ b/content/v2/troubleshooting-application-dev.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v2/troubleshooting-application-dev.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v2/troubleshooting-application-dev.md"
 
 ---
 

--- a/content/v2/upgrade.md
+++ b/content/v2/upgrade.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v2/upgrade.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v2/upgrade.md"
 
 ---
 - [Are You on the Latest Version?](#are-you-on-the-latest-version)

--- a/content/v2/url-shortener-tutorial.md
+++ b/content/v2/url-shortener-tutorial.md
@@ -2,7 +2,7 @@ title = "Building a URL Shortener With Spin"
 template = "main"
 date = "2023-11-04T00:00:01Z"
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v2/url-shortener-tutorial.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v2/url-shortener-tutorial.md"
 
 ---
 - [A Simple URL Shortener Built With Spin](#a-simple-url-shortener-built-with-spin)

--- a/content/v2/variables.md
+++ b/content/v2/variables.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v2/variables.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v2/variables.md"
 
 ---
 - [Adding Variables to Your Applications](#adding-variables-to-your-applications)

--- a/content/v2/writing-apps.md
+++ b/content/v2/writing-apps.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v2/writing-apps.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v2/writing-apps.md"
 
 ---
 - [Writing an Application Manifest](#writing-an-application-manifest)

--- a/content/v3/ai-sentiment-analysis-api-tutorial.md
+++ b/content/v3/ai-sentiment-analysis-api-tutorial.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v3/ai-sentiment-analysis-api-tutorial.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v3/ai-sentiment-analysis-api-tutorial.md"
 
 ---
 

--- a/content/v3/api-guides-overview.md
+++ b/content/v3/api-guides-overview.md
@@ -2,7 +2,7 @@ title = "API Support Overview"
 template = "main"
 date = "2023-11-04T00:00:01Z"
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v3/api-guides-overview.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v3/api-guides-overview.md"
 
 ---
 

--- a/content/v3/build.md
+++ b/content/v3/build.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v3/build.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v3/build.md"
 
 ---
 

--- a/content/v3/cache.md
+++ b/content/v3/cache.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v3/cache.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v3/cache.md"
 
 ---
 

--- a/content/v3/contributing-docs.md
+++ b/content/v3/contributing-docs.md
@@ -2,7 +2,7 @@ title = "Contributing to Docs"
 template = "main"
 date = "2023-11-04T00:00:01Z"
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v3/contributing-docs.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v3/contributing-docs.md"
 keywords = "contribute contributing"
 
 ---
@@ -276,9 +276,9 @@ $ npm run test
 
 ```bash
 # Example of how to lint all Markdown files in a local folder (in this case the spin folder) 
-npx markdownlint-cli2 content/spin/*.md \"#node_modules\"
+npx markdownlint-cli2 content/*.md \"#node_modules\"
 # Example of how to lint a local Markdown file
-npx markdownlint-cli2 content/spin/install.md \"#node_modules\"
+npx markdownlint-cli2 content/install.md \"#node_modules\"
 ```
 
 **Note:** Whilst the `npm run test` command (which lints and also programmatically checks all URLs) does take extra time to complete it **must** be utilized before you [push changes](#10-push-changes); preventing the potential pushing of broken URLs to the documentation site.
@@ -332,7 +332,7 @@ If you create a new markdown file and/or you notice a file without the explicit 
 
 ```
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v3/contributing-docs.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v3/contributing-docs.md"
 ```
 
 ### 6.5 How To Properly Edit CSS Styles
@@ -435,16 +435,16 @@ The `bart check` command can be used to check the content. Simply pass in the co
 <!-- @selectiveCpy -->
 
 ```bash
-$ bart check --shortcodes ./shortcodes content/spin/variables.md
+$ bart check --shortcodes ./shortcodes content/variables.md
 shortcodes: registering alert
 shortcodes: registering details
 shortcodes: registering tabs
 shortcodes: registering startTab
 shortcodes: registering blockEnd
-✅ content/spin/variables.md
+✅ content/variables.md
 ```
 
-> Note: `using a wildcard `*` will check a whole directory via a single command. For example, running `bart check --shortcodes ./shortcodes content/spin/*` will check all markdown files in the Spin project's documentation section.
+> Note: `using a wildcard `*` will check a whole directory via a single command. For example, running `bart check --shortcodes ./shortcodes content/*` will check all markdown files in the Spin project's documentation section.
 
 ### 8. Add Changes
 

--- a/content/v3/contributing-spin.md
+++ b/content/v3/contributing-spin.md
@@ -2,7 +2,7 @@ title = "Contributing to Spin"
 template = "main"
 date = "2023-11-04T00:00:01Z"
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v3/contributing-spin.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v3/contributing-spin.md"
 
 ---
 - [Developer Community Calls](#developer-community-calls)

--- a/content/v3/deploying.md
+++ b/content/v3/deploying.md
@@ -2,7 +2,7 @@ title = "Deploy Options"
 template = "main"
 date = "2023-11-04T00:00:01Z"
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v3/deploying-to-fermyon.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v3/deploying-to-fermyon.md"
 
 ---
 

--- a/content/v3/distributing-apps.md
+++ b/content/v3/distributing-apps.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v3/distributing-apps.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v3/distributing-apps.md"
 
 ---
 - [Logging Into a Registry](#logging-into-a-registry)

--- a/content/v3/dynamic-configuration.md
+++ b/content/v3/dynamic-configuration.md
@@ -2,7 +2,7 @@ title = "Dynamic and Runtime Application Configuration"
 template = "main"
 date = "2023-11-04T00:00:01Z"
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v3/dynamic-configuration.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v3/dynamic-configuration.md"
 
 ---
 

--- a/content/v3/extending-and-embedding.md
+++ b/content/v3/extending-and-embedding.md
@@ -2,7 +2,7 @@ title = "Extending and Embedding Spin"
 template = "main"
 date = "2023-11-04T00:00:01Z"
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v3/extending-and-embedding.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v3/extending-and-embedding.md"
 
 ---
 - [Extending Spin with a Custom Trigger](#extending-spin-with-a-custom-trigger)

--- a/content/v3/go-components.md
+++ b/content/v3/go-components.md
@@ -2,7 +2,7 @@ title = "Building Spin components in Go"
 template = "main"
 date = "2023-11-04T00:00:01Z"
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v3/go-components.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v3/go-components.md"
 
 ---
 

--- a/content/v3/http-outbound.md
+++ b/content/v3/http-outbound.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v3/http-outbound.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v3/http-outbound.md"
 
 ---
 - [Using HTTP From Applications](#using-http-from-applications)

--- a/content/v3/http-trigger.md
+++ b/content/v3/http-trigger.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v3/http-trigger.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v3/http-trigger.md"
 
 ---
 - [Specifying an HTTP Trigger](#specifying-an-http-trigger)

--- a/content/v3/index.md
+++ b/content/v3/index.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v3/index.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v3/index.md"
 
 ---
 

--- a/content/v3/install.md
+++ b/content/v3/install.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v3/install.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v3/install.md"
 keywords = "install"
 
 ---

--- a/content/v3/javascript-components.md
+++ b/content/v3/javascript-components.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v3/javascript-components.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v3/javascript-components.md"
 
 ---
 - [Installing Templates](#installing-templates)

--- a/content/v3/key-value-store-tutorial.md
+++ b/content/v3/key-value-store-tutorial.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v3/key-value-store-tutorial.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v3/key-value-store-tutorial.md"
 
 ---
 - [Key Value Store With Spin Applications](#key-value-store-with-spin-applications)

--- a/content/v3/kubernetes.md
+++ b/content/v3/kubernetes.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2024-03-07T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v3/kubernetes.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v3/kubernetes.md"
 
 ---
 

--- a/content/v3/kv-store-api-guide.md
+++ b/content/v3/kv-store-api-guide.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v3/kv-store-api-guide.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v3/kv-store-api-guide.md"
 
 ---
 - [Using Key Value Store From Applications](#using-key-value-store-from-applications)

--- a/content/v3/language-support-overview.md
+++ b/content/v3/language-support-overview.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v3/language-support-overview.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v3/language-support-overview.md"
 
 ---
 

--- a/content/v3/managing-plugins.md
+++ b/content/v3/managing-plugins.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v3/managing-plugins.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v3/managing-plugins.md"
 
 ---
 - [Installing Plugins](#installing-plugins)

--- a/content/v3/managing-templates.md
+++ b/content/v3/managing-templates.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v3/managing-templates.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v3/managing-templates.md"
 
 ---
 - [Installing Templates](#installing-templates)

--- a/content/v3/manifest-reference-v1.md
+++ b/content/v3/manifest-reference-v1.md
@@ -2,7 +2,7 @@ title = "Spin Application Manifest (Version 1) Reference"
 template = "main"
 date = "2023-11-04T00:00:01Z"
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v3/manifest-reference-v1.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v3/manifest-reference-v1.md"
 
 ---
 - [Format](#format)

--- a/content/v3/manifest-reference.md
+++ b/content/v3/manifest-reference.md
@@ -2,7 +2,7 @@ title = "Spin Application Manifest Reference"
 template = "main"
 date = "2023-11-04T00:00:01Z"
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v3/manifest-reference.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v3/manifest-reference.md"
 
 ---
 - [Manifest Format](#manifest-format)

--- a/content/v3/migration-v2-v3.md
+++ b/content/v3/migration-v2-v3.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v3/migration-v2-v3.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v3/migration-v2-v3.md"
 
 ---
 

--- a/content/v3/mqtt-outbound.md
+++ b/content/v3/mqtt-outbound.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v3/mqtt-outbound.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v3/mqtt-outbound.md"
 
 ---
 - [Sending MQTT Messages From Applications](#sending-mqtt-messages-from-applications)

--- a/content/v3/observing-apps.md
+++ b/content/v3/observing-apps.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v3/observing-apps.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v3/observing-apps.md"
 
 ---
 

--- a/content/v3/other-languages.md
+++ b/content/v3/other-languages.md
@@ -2,7 +2,7 @@ title = "Building Spin components in other languages"
 template = "main"
 date = "2023-11-04T00:00:01Z"
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v3/other-languages.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v3/other-languages.md"
 
 ---
 - [C/C++](#cc)

--- a/content/v3/plugin-authoring.md
+++ b/content/v3/plugin-authoring.md
@@ -2,7 +2,7 @@ title = "Creating Spin Plugins"
 template = "main"
 date = "2023-11-04T00:00:01Z"
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v3/plugin-authoring.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v3/plugin-authoring.md"
 
 ---
 - [What Are Spin Plugins?](#what-are-spin-plugins)

--- a/content/v3/python-components.md
+++ b/content/v3/python-components.md
@@ -2,7 +2,7 @@ title = "Building Spin Components in Python"
 template = "main"
 date = "2023-11-04T00:00:01Z"
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v3/python-components.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v3/python-components.md"
 
 ---
 - [Prerequisite](#prerequisite)

--- a/content/v3/quickstart.md
+++ b/content/v3/quickstart.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v3/quickstart.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v3/quickstart.md"
 keywords = "quickstart"
 
 ---

--- a/content/v3/rdbms-storage.md
+++ b/content/v3/rdbms-storage.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v3/rdbms-storage.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v3/rdbms-storage.md"
 
 ---
 - [Using MySQL and PostgreSQL From Applications](#using-mysql-and-postgresql-from-applications)

--- a/content/v3/redis-outbound.md
+++ b/content/v3/redis-outbound.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v3/redis-outbound.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v3/redis-outbound.md"
 
 ---
 - [Using Redis From Applications](#using-redis-from-applications)

--- a/content/v3/redis-trigger.md
+++ b/content/v3/redis-trigger.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v3/redis-trigger.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v3/redis-trigger.md"
 
 ---
 - [Specifying a Redis Trigger](#specifying-a-redis-trigger)

--- a/content/v3/registry-tutorial.md
+++ b/content/v3/registry-tutorial.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v3/registry-tutorial.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v3/registry-tutorial.md"
 
 ---
 - [Spin Registry Support](#spin-registry-support)

--- a/content/v3/running-apps.md
+++ b/content/v3/running-apps.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v3/running-apps.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v3/running-apps.md"
 
 ---
 - [Specifying the Application to Run](#specifying-the-application-to-run)

--- a/content/v3/rust-components.md
+++ b/content/v3/rust-components.md
@@ -2,7 +2,7 @@ title = "Building Spin components in Rust"
 template = "main"
 date = "2023-11-04T00:00:01Z"
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v3/rust-components.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v3/rust-components.md"
 
 ---
 - [Prerequisites](#prerequisites)

--- a/content/v3/see-what-people-have-built-with-spin.md
+++ b/content/v3/see-what-people-have-built-with-spin.md
@@ -2,7 +2,7 @@ title = "Built With Spin"
 template = "main"
 date = "2023-11-04T00:00:01Z"
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v3/see-what-people-have-built-with-spin.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v3/see-what-people-have-built-with-spin.md"
 
 ---
 - [AI-powered bookmarking app with Python and WebAssembly](#ai-powered-bookmarking-app-with-python-and-webassembly)

--- a/content/v3/serverless-ai-api-guide.md
+++ b/content/v3/serverless-ai-api-guide.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v3/serverless-ai-api-guide.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v3/serverless-ai-api-guide.md"
 
 ---
 - [Using Serverless AI From Applications](#using-serverless-ai-from-applications)

--- a/content/v3/serverless-ai-hello-world.md
+++ b/content/v3/serverless-ai-hello-world.md
@@ -5,7 +5,7 @@ template = "main"
 tags = ["ai", "serverless", "getting started"]
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v3/serverless-ai-hello-world.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v3/serverless-ai-hello-world.md"
 
 ---
 

--- a/content/v3/spin-application-structure.md
+++ b/content/v3/spin-application-structure.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v3/spin-application-structure.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v3/spin-application-structure.md"
 keywords = "structure"
 
 ---

--- a/content/v3/sqlite-api-guide.md
+++ b/content/v3/sqlite-api-guide.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v3/sqlite-api-guide.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v3/sqlite-api-guide.md"
 
 ---
 - [Granting SQLite Database Permissions to Components](#granting-sqlite-database-permissions-to-components)

--- a/content/v3/template-authoring.md
+++ b/content/v3/template-authoring.md
@@ -2,7 +2,7 @@ title = "Creating Spin templates"
 template = "main"
 date = "2023-11-04T00:00:01Z"
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v3/template-authoring.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v3/template-authoring.md"
 
 ---
 - [Authoring the Content](#authoring-the-content)

--- a/content/v3/testing-apps.md
+++ b/content/v3/testing-apps.md
@@ -2,7 +2,7 @@ title = "Testing Applications"
 template = "main"
 date = "2024-05-05T00:00:01Z"
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v3/testing-apps.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v3/testing-apps.md"
 
 ---
 

--- a/content/v3/triggers.md
+++ b/content/v3/triggers.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v3/triggers.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v3/triggers.md"
 
 ---
 - [Triggers and Components](#triggers-and-components)

--- a/content/v3/troubleshooting-application-dev.md
+++ b/content/v3/troubleshooting-application-dev.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v3/troubleshooting-application-dev.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v3/troubleshooting-application-dev.md"
 
 ---
 

--- a/content/v3/upgrade.md
+++ b/content/v3/upgrade.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v3/upgrade.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v3/upgrade.md"
 
 ---
 - [Are You on the Latest Version?](#are-you-on-the-latest-version)

--- a/content/v3/url-shortener-tutorial.md
+++ b/content/v3/url-shortener-tutorial.md
@@ -2,7 +2,7 @@ title = "Building a URL Shortener With Spin"
 template = "main"
 date = "2023-11-04T00:00:01Z"
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v3/url-shortener-tutorial.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v3/url-shortener-tutorial.md"
 
 ---
 - [A Simple URL Shortener Built With Spin](#a-simple-url-shortener-built-with-spin)

--- a/content/v3/variables.md
+++ b/content/v3/variables.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v3/variables.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v3/variables.md"
 
 ---
 - [Adding Variables to Your Applications](#adding-variables-to-your-applications)

--- a/content/v3/writing-apps.md
+++ b/content/v3/writing-apps.md
@@ -3,7 +3,7 @@ template = "main"
 date = "2023-11-04T00:00:01Z"
 enable_shortcodes = true
 [extra]
-url = "https://github.com/spinframework/spin-docs/blob/main/content/spin/v3/writing-apps.md"
+url = "https://github.com/spinframework/spin-docs/blob/main/content/v3/writing-apps.md"
 
 ---
 - [Writing an Application Manifest](#writing-an-application-manifest)

--- a/scripts/spin.rhai
+++ b/scripts/spin.rhai
@@ -22,7 +22,7 @@ let spin_pages = [];
 // Get each page, assigning it to {path: object}.
 let keys = pages.keys();
 for item in keys {
-    if item.index_of("/content/spin/") == 0 {
+    if item.index_of("/content/") == 0 {
         // Remove /content and .md
         let path = item.sub_string(8);
         let page = pages[item];


### PR DESCRIPTION
- Replaces instances of `content/spin/` with `content/`; should fix _some_ of the broken links uncovered in https://github.com/spinframework/spin-docs/pull/28