### PR TITLE
Port post-fork changes

### DIFF
--- a/content/v2/http-outbound.md
+++ b/content/v2/http-outbound.md
@@ -216,7 +216,9 @@ You must still grant permission by including the relevant `spin.internal` hosts 
 allowed_outbound_hosts = ["http://authz.spin.internal", "https://reporting.spin.internal"]
 ```
 
-To allow local chaining to _any_ component in your application, use a subdomain wildcard:
+You may use either the `http` or `https` scheme, and the scheme in the service chaining request is ignored: only the special host name matters.
+
+To allow local chaining to _any_ component in your application, you can use a subdomain wildcard:
 
 ```toml
 allowed_outbound_hosts = ["http://*.spin.internal"]

--- a/content/v2/http-trigger.md
+++ b/content/v2/http-trigger.md
@@ -265,11 +265,11 @@ For a full Rust SDK reference, see the [Rust Spin SDK documentation](https://doc
 
 {{ startTab "TypeScript"}}
 
-> [**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/spin-js-sdk/)
+> [**Want to go straight to the reference documentation?**  Find it here.](https://spinframework.github.io/spin-js-sdk/v2.3/)
 
 The user must a define a function named `handler` which the SDK attaches to the [`FetchEvent` listener](https://developer.mozilla.org/en-US/docs/Web/API/FetchEvent). Note that the incoming HTTP event is translated to a `FetchEvent`.
 
-The handler function takes in two arguments a [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) and a [ResponseBuilder](https://fermyon.github.io/spin-js-sdk/classes/ResponseBuilder.html)
+The handler function takes in two arguments a [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) and a [ResponseBuilder](https://spinframework.github.io/spin-js-sdk/v2.3/classes/ResponseBuilder.html)
 
 ```ts
 import { ResponseBuilder } from "@fermyon/spin-sdk";

--- a/content/v2/javascript-components.md
+++ b/content/v2/javascript-components.md
@@ -31,7 +31,7 @@ With JavaScript being a very popular language, Spin provides an SDK to support b
 
 > All examples from this page can be found in [the JavaScript SDK repository on GitHub](https://github.com/spinframework/spin-js-sdk/tree/sdk-v2/examples).
 
-[**Want to go straight to the Spin SDK reference documentation?**  Find it here.](https://fermyon.github.io/spin-js-sdk/)
+[**Want to go straight to the Spin SDK reference documentation?**  Find it here.](https://spinframework.github.io/spin-js-sdk/v2.3/)
 
 ## Installing Templates
 

--- a/content/v2/kv-store-api-guide.md
+++ b/content/v2/kv-store-api-guide.md
@@ -83,9 +83,9 @@ fn handle_request(_req: Request) -> Result<impl IntoResponse> {
 
 {{ startTab "Typescript"}}
 
-> [**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/spin-js-sdk/)
+> [**Want to go straight to the reference documentation?**  Find it here.](https://spinframework.github.io/spin-js-sdk/v2.3/)
 
-The key value functions can be accessed after opening a store using either [the `Kv.open` or the `Kv.openDefault` methods](https://fermyon.github.io/spin-js-sdk/modules/Kv.html) which returns a [handle to the store](https://fermyon.github.io/spin-js-sdk/interfaces/Kv.Store.html). For example:
+The key value functions can be accessed after opening a store using either [the `Kv.open` or the `Kv.openDefault` methods](https://spinframework.github.io/spin-js-sdk/v2.3/modules/Kv.html) which returns a [handle to the store](https://spinframework.github.io/spin-js-sdk/v2.3/interfaces/Kv.Store.html). For example:
 
 ```ts
 import { ResponseBuilder , Kv} from "@fermyon/spin-sdk";
@@ -102,14 +102,14 @@ export async function handler(req: Request, res: ResponseBuilder) {
 **General Notes**
 - The SDK doesn't surface the `close` operation. It automatically closes all stores at the end of the request; there's no way to close them early.
 
-[`get` **Operation**](https://fermyon.github.io/spin-js-sdk/interfaces/Kv.Store.html#get)
+[`get` **Operation**](https://spinframework.github.io/spin-js-sdk/v2.3/interfaces/Kv.Store.html#get)
 - The result is of the type `Uint8Array | null`
 - If the key does not exist, `get` returns `null`
 
-[`set` **Operation**](https://fermyon.github.io/spin-js-sdk/interfaces/Kv.Store.html#set)
+[`set` **Operation**](https://spinframework.github.io/spin-js-sdk/v2.3/interfaces/Kv.Store.html#set)
 - The value argument is of the type `Uint8Array | string | object`.
 
-[`setJson`](https://fermyon.github.io/spin-js-sdk/interfaces/Kv.Store.html#setJson) and [`getJson` **Operation**](https://fermyon.github.io/spin-js-sdk/interfaces/Kv.Store.html#getJson)
+[`setJson`](https://spinframework.github.io/spin-js-sdk/v2.3/interfaces/Kv.Store.html#setJson) and [`getJson` **Operation**](https://spinframework.github.io/spin-js-sdk/v2.3/interfaces/Kv.Store.html#getJson)
 - Applications can store JavaScript objects using `setJson`; these are serialized within the store as JSON. These serialized objects can be retrieved and deserialized using `getJson`. If you call `getJson` on a key that doesn't exist then it returns an empty object.
 
 {{ blockEnd }}

--- a/content/v2/language-support-overview.md
+++ b/content/v2/language-support-overview.md
@@ -37,7 +37,7 @@ This page contains information about language support for Spin features:
 
 {{ startTab "TypeScript"}}
 
-**[📄 Visit the JS/TS Spin SDK reference documentation](https://fermyon.github.io/spin-js-sdk/) to see specific modules, functions, variables and syntax relating to the following TS/JS features.**
+**[📄 Visit the JS/TS Spin SDK reference documentation](https://spinframework.github.io/spin-js-sdk/v2.3/) to see specific modules, functions, variables and syntax relating to the following TS/JS features.**
 
 | Feature | SDK Supported? |
 |-----|-----|

--- a/content/v2/mqtt-outbound.md
+++ b/content/v2/mqtt-outbound.md
@@ -57,7 +57,7 @@ You can find a complete Rust code example for using outbound MQTT from an HTTP c
 
 {{ startTab "TypeScript"}}
 
-> [**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/spin-js-sdk/modules/Mqtt.html)
+> [**Want to go straight to the reference documentation?**  Find it here.](https://spinframework.github.io/spin-js-sdk/v2.3/modules/Mqtt.html)
 
 To access an MQTT server, use the `Mqtt.open` function.
 
@@ -72,7 +72,7 @@ let catPicture = new Uint8Array(await req.arraybuffer());
 connection.publish("pets", catPicture, QoS.AtleastOnce);
 ```
 
-For full details of the MQTT API, see the [Spin SDK reference documentation](https://fermyon.github.io/spin-js-sdk/modules/Mqtt.html)
+For full details of the MQTT API, see the [Spin SDK reference documentation](https://spinframework.github.io/spin-js-sdk/v2.3/modules/Mqtt.html)
 
 You can find a complete Rust code example for using outbound MQTT from an HTTP component in the [Spin Rust SDK repository on GitHub](https://github.com/spinframework/spin-js-sdk/tree/sdk-v2/examples/spin-host-apis/spin-mqtt).
 

--- a/content/v2/rdbms-storage.md
+++ b/content/v2/rdbms-storage.md
@@ -71,7 +71,7 @@ For full information about the MySQL and PostgreSQL APIs, see [the Spin SDK refe
 
 {{ startTab "TypeScript"}}
 
-> [**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/spin-js-sdk/)
+> [**Want to go straight to the reference documentation?**  Find it here.](https://spinframework.github.io/spin-js-sdk/v2.3/)
 
 The code below is an [Outbound MySQL example](https://github.com/spinframework/spin-js-sdk/tree/sdk-v2/examples/spin-host-apis/spin-mysql). There is also an outbound [PostgreSQL example](https://github.com/spinframework/spin-js-sdk/tree/sdk-v2/examples/spin-host-apis/spin-postgres) available.
 

--- a/content/v2/redis-outbound.md
+++ b/content/v2/redis-outbound.md
@@ -89,9 +89,9 @@ You can find a complete Rust code example for using outbound Redis from an HTTP 
 
 {{ startTab "TypeScript"}}
 
-> [**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/spin-js-sdk/)
+> [**Want to go straight to the reference documentation?**  Find it here.](https://spinframework.github.io/spin-js-sdk/v2.3/)
 
-Redis functions are available on [the `Redis` module](https://fermyon.github.io/spin-js-sdk/modules/Redis.html). The function names match the operations above. For example:
+Redis functions are available on [the `Redis` module](https://spinframework.github.io/spin-js-sdk/v2.3/modules/Redis.html). The function names match the operations above. For example:
 
 ```javascript
 import { Redis } from "@fermyon/spin-sdk"

--- a/content/v2/serverless-ai-api-guide.md
+++ b/content/v2/serverless-ai-api-guide.md
@@ -112,9 +112,9 @@ The `infer_with_options` examples, operation:
 
 {{ startTab "Typescript"}}
 
-> [**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/spin-js-sdk/modules/Llm.html)
+> [**Want to go straight to the reference documentation?**  Find it here.](https://spinframework.github.io/spin-js-sdk/v2.3/modules/Llm.html)
 
-To use Serverless AI functions, [the `Llm` module](https://fermyon.github.io/spin-js-sdk/modules/Llm.html) from the Spin SDK provides two methods: `infer` and `generateEmbeddings`. For example: 
+To use Serverless AI functions, [the `Llm` module](https://spinframework.github.io/spin-js-sdk/v2.3/modules/Llm.html) from the Spin SDK provides two methods: `infer` and `generateEmbeddings`. For example: 
 
 ```javascript
 import { ResponseBuilder, Llm} from "@fermyon/spin-sdk"
@@ -134,15 +134,15 @@ export async function handler(req: Request, res: ResponseBuilder) {
 `infer` operation:
 
 - It takes in the following arguments - model name, prompt and a optional third parameter for inferencing options. 
-- The model name is a string. There are enums for the inbuilt models (llama2-chat and codellama) in [`InferencingModels`](https://fermyon.github.io/spin-js-sdk/enums/Llm.InferencingModels.html).
-- The optional third parameter which is an [InferencingOptions](https://fermyon.github.io/spin-js-sdk/interfaces/Llm.InferencingOptions.html) interface allows you to specify parameters such as `maxTokens`, `repeatPenalty`, `repeatPenaltyLastNTokenCount`, `temperature`, `topK`, `topP`.  
-- The return value is an [`InferenceResult`](https://fermyon.github.io/spin-js-sdk/interfaces/Llm.EmbeddingResult.html).
+- The model name is a string. There are enums for the inbuilt models (llama2-chat and codellama) in [`InferencingModels`](https://spinframework.github.io/spin-js-sdk/v2.3/enums/Llm.InferencingModels.html).
+- The optional third parameter which is an [InferencingOptions](https://spinframework.github.io/spin-js-sdk/v2.3/interfaces/Llm.InferencingOptions.html) interface allows you to specify parameters such as `maxTokens`, `repeatPenalty`, `repeatPenaltyLastNTokenCount`, `temperature`, `topK`, `topP`.  
+- The return value is an [`InferenceResult`](https://spinframework.github.io/spin-js-sdk/v2.3/interfaces/Llm.EmbeddingResult.html).
 
 `generateEmbeddings` operation:
 
 - It takes two arguments - model name and list of strings to generate the embeddings for. 
-- The model name is a string. There are enums for the inbuilt models (AllMiniLmL6V2) in [`EmbeddingModels`](https://fermyon.github.io/spin-js-sdk/enums/Llm.EmbeddingModels.html).
-- The return value is an [`EmbeddingResult`](https://fermyon.github.io/spin-js-sdk/interfaces/Llm.EmbeddingResult.html)
+- The model name is a string. There are enums for the inbuilt models (AllMiniLmL6V2) in [`EmbeddingModels`](https://spinframework.github.io/spin-js-sdk/v2.3/enums/Llm.EmbeddingModels.html).
+- The return value is an [`EmbeddingResult`](https://spinframework.github.io/spin-js-sdk/v2.3/interfaces/Llm.EmbeddingResult.html)
 
 {{ blockEnd }}
 

--- a/content/v2/sqlite-api-guide.md
+++ b/content/v2/sqlite-api-guide.md
@@ -120,9 +120,9 @@ struct ToDo {
 
 {{ startTab "Typescript"}}
 
-> [**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/spin-js-sdk/modules/Sqlite.html)
+> [**Want to go straight to the reference documentation?**  Find it here.](https://spinframework.github.io/spin-js-sdk/v2.3/modules/Sqlite.html)
 
-To use SQLite functions, use [the `Sqlite.open` or `Sqlite.openDefault` function](https://fermyon.github.io/spin-js-sdk/modules/Sqlite.html) to obtain [a `SqliteConnection` object](https://fermyon.github.io/spin-js-sdk/interfaces/Sqlite.SqliteConnection.html). `SqliteConnection` provides the `execute` method as described above. For example:
+To use SQLite functions, use [the `Sqlite.open` or `Sqlite.openDefault` function](https://spinframework.github.io/spin-js-sdk/v2.3/modules/Sqlite.html) to obtain [a `SqliteConnection` object](https://spinframework.github.io/spin-js-sdk/v2.3/interfaces/Sqlite.SqliteConnection.html). `SqliteConnection` provides the `execute` method as described above. For example:
 
 ```javascript
 import { ResponseBuilder, Sqlite } from "@fermyon/spin-sdk";

--- a/content/v2/variables.md
+++ b/content/v2/variables.md
@@ -133,7 +133,7 @@ async fn handle_api_call_with_token(_req: Request) -> anyhow::Result<impl IntoRe
 
 {{ startTab "TypeScript"}}
 
-> [**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/spin-js-sdk/modules/Variables.html)
+> [**Want to go straight to the reference documentation?**  Find it here.](https://spinframework.github.io/spin-js-sdk/v2.3/modules/Variables.html)
 
 ```ts
 import { ResponseBuilder, Variables } from "@fermyon/spin-sdk";

--- a/content/v3/http-outbound.md
+++ b/content/v3/http-outbound.md
@@ -219,6 +219,8 @@ You must still grant permission by including the relevant `spin.internal` hosts 
 allowed_outbound_hosts = ["http://authz.spin.internal", "https://reporting.spin.internal"]
 ```
 
+You may use either the `http` or `https` scheme, and the scheme in the service chaining request is ignored: only the special host name matters.
+
 To allow local chaining to _any_ component in your application, you can use a subdomain wildcard:
 
 ```toml

--- a/content/v3/http-trigger.md
+++ b/content/v3/http-trigger.md
@@ -256,19 +256,25 @@ For a full Rust SDK reference, see the [Rust Spin SDK documentation](https://doc
 
 {{ startTab "TypeScript"}}
 
-> [**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/spin-js-sdk/)
+> [**Want to go straight to the reference documentation?**  Find it here.](https://spinframework.github.io/spin-js-sdk/stable/)
 
-The user must a define a function named `handler` which the SDK attaches to the [`FetchEvent` listener](https://developer.mozilla.org/en-US/docs/Web/API/FetchEvent). Note that the incoming HTTP event is translated to a `FetchEvent`.
+Building a Spin HTTP component with the JavaScript/TypeScript SDK now involves adding an event listener for the `fetch` event. This event listener handles incoming HTTP requests and allows you to construct and return HTTP responses.
 
-The handler function takes in two arguments a [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) and a [ResponseBuilder](https://fermyon.github.io/spin-js-sdk/classes/ResponseBuilder.html)
+Below is a complete implementation for such a component in TypeScript:
 
 ```ts
-import { ResponseBuilder } from "@fermyon/spin-sdk";
+import { AutoRouter } from 'itty-router';
 
-export async function handler(req: Request, res: ResponseBuilder) {
-    console.log(req);
-    res.send("hello universe");
-}
+let router = AutoRouter();
+
+router
+    .get("/", () => new Response("hello universe"))
+    .get('/hello/:name', ({ name }) => `Hello, ${name}!`)
+
+//@ts-ignore
+addEventListener('fetch', async (event: FetchEvent) => {
+    event.respondWith(router.fetch(event.request));
+});
 ```
 
 {{ blockEnd }}

--- a/content/v3/http-trigger.md
+++ b/content/v3/http-trigger.md
@@ -496,11 +496,11 @@ When exposing HTTP triggers using HTTPS you must provide `spin up` with a TLS ce
 
 ### Trigger Options
 
-The `spin up` command's `--tls-cert` and `--tls-key` trigger options provide a way for you to specify both a TLS certificate and a private key (whilst running the `spin up` command).
+The `spin up` command accepts some HTTP-trigger-specific options:
 
-The `--tls-cert` option specifies the path to the TLS certificate to use for HTTPS, if this is not set, normal HTTP will be used. The certificate should be in PEM format. 
+The `--listen` option sets the local IP and port that `spin up` should listen to for requests. By default, it listens to `localhost:3000`.
 
-The `--tls-key` option specifies the path to the private key to use for HTTPS, if this is not set, normal HTTP will be used. The key should be in PKCS#8 format.
+The `--tls-cert` and `--tls-key` options provide a way for you to configure a TLS certificate. If they are not set, plaintext HTTP will be used. The `--tls-cert` option specifies the path to the TLS certificate to use for HTTPS. The certificate should be in PEM format. The `--tls-key` option specifies the path to the private key to use for HTTPS. The key should be in PKCS#8 format.
 
 ### Environment Variables
 

--- a/content/v3/javascript-components.md
+++ b/content/v3/javascript-components.md
@@ -31,7 +31,7 @@ With JavaScript being a very popular language, Spin provides an SDK to support b
 
 > All examples from this page can be found in [the JavaScript SDK repository on GitHub](https://github.com/spinframework/spin-js-sdk/tree/main/examples).
 
-[**Want to go straight to the Spin SDK reference documentation?**  Find it here.](https://fermyon.github.io/spin-js-sdk/)
+[**Want to go straight to the Spin SDK reference documentation?**  Find it here.](https://spinframework.github.io/spin-js-sdk/stable/)
 
 ## Installing Templates
 

--- a/content/v3/kv-store-api-guide.md
+++ b/content/v3/kv-store-api-guide.md
@@ -83,9 +83,9 @@ fn handle_request(_req: Request) -> Result<impl IntoResponse> {
 
 {{ startTab "Typescript"}}
 
-> [**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/spin-js-sdk/)
+> [**Want to go straight to the reference documentation?**  Find it here.](https://spinframework.github.io/spin-js-sdk/stable/)
 
-The key value functions can be accessed after opening a store using either [the `Kv.open` or the `Kv.openDefault` methods](https://fermyon.github.io/spin-js-sdk/modules/Kv.html) which returns a [handle to the store](https://fermyon.github.io/spin-js-sdk/interfaces/Kv.Store.html). For example:
+The key value functions can be accessed after opening a store using either [the `Kv.open` or the `Kv.openDefault` methods](https://spinframework.github.io/spin-js-sdk/stable/modules/Kv.html) which returns a [handle to the store](https://spinframework.github.io/spin-js-sdk/stable/interfaces/Kv.Store.html). For example:
 
 ```ts
 import { AutoRouter } from 'itty-router';
@@ -109,14 +109,14 @@ addEventListener('fetch', async (event: FetchEvent) => {
 **General Notes**
 - The SDK doesn't surface the `close` operation. It automatically closes all stores at the end of the request; there's no way to close them early.
 
-[`get` **Operation**](https://fermyon.github.io/spin-js-sdk/interfaces/Kv.Store.html#get)
+[`get` **Operation**](https://spinframework.github.io/spin-js-sdk/stable/interfaces/Kv.Store.html#get)
 - The result is of the type `Uint8Array | null`
 - If the key does not exist, `get` returns `null`
 
-[`set` **Operation**](https://fermyon.github.io/spin-js-sdk/interfaces/Kv.Store.html#set)
+[`set` **Operation**](https://spinframework.github.io/spin-js-sdk/stable/interfaces/Kv.Store.html#set)
 - The value argument is of the type `Uint8Array | string | object`.
 
-[`setJson`](https://fermyon.github.io/spin-js-sdk/interfaces/Kv.Store.html#setJson) and [`getJson` **Operation**](https://fermyon.github.io/spin-js-sdk/interfaces/Kv.Store.html#getJson)
+[`setJson`](https://spinframework.github.io/spin-js-sdk/stable/interfaces/Kv.Store.html#setJson) and [`getJson` **Operation**](https://spinframework.github.io/spin-js-sdk/stable/interfaces/Kv.Store.html#getJson)
 - Applications can store JavaScript objects using `setJson`; these are serialized within the store as JSON. These serialized objects can be retrieved and deserialized using `getJson`. If you call `getJson` on a key that doesn't exist then it returns an empty object.
 
 {{ blockEnd }}

--- a/content/v3/language-support-overview.md
+++ b/content/v3/language-support-overview.md
@@ -37,7 +37,7 @@ This page contains information about language support for Spin features:
 
 {{ startTab "TypeScript"}}
 
-**[📄 Visit the JS/TS Spin SDK reference documentation](https://fermyon.github.io/spin-js-sdk/) to see specific modules, functions, variables and syntax relating to the following TS/JS features.**
+**[📄 Visit the JS/TS Spin SDK reference documentation](https://spinframework.github.io/spin-js-sdk/stable/) to see specific modules, functions, variables and syntax relating to the following TS/JS features.**
 
 | Feature | SDK Supported? |
 |-----|-----|

--- a/content/v3/mqtt-outbound.md
+++ b/content/v3/mqtt-outbound.md
@@ -57,7 +57,7 @@ You can find a complete Rust code example for using outbound MQTT from an HTTP c
 
 {{ startTab "TypeScript"}}
 
-> [**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/spin-js-sdk/modules/Mqtt.html)
+> [**Want to go straight to the reference documentation?**  Find it here.](https://spinframework.github.io/spin-js-sdk/stable/modules/Mqtt.html)
 
 To access an MQTT server, use the `Mqtt.open` function.
 
@@ -72,7 +72,7 @@ let catPicture = new Uint8Array(await req.arraybuffer());
 connection.publish("pets", catPicture, QoS.AtleastOnce);
 ```
 
-For full details of the MQTT API, see the [Spin SDK reference documentation](https://fermyon.github.io/spin-js-sdk/modules/Mqtt.html)
+For full details of the MQTT API, see the [Spin SDK reference documentation](https://spinframework.github.io/spin-js-sdk/stable/modules/Mqtt.html)
 
 You can find a complete Rust code example for using outbound MQTT from an HTTP component in the [Spin Rust SDK repository on GitHub](https://github.com/spinframework/spin-js-sdk/tree/main/examples/spin-host-apis/spin-mqtt).
 

--- a/content/v3/rdbms-storage.md
+++ b/content/v3/rdbms-storage.md
@@ -73,7 +73,7 @@ For full information about the MySQL and PostgreSQL APIs, see [the Spin SDK refe
 
 {{ startTab "TypeScript"}}
 
-> [**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/spin-js-sdk/)
+> [**Want to go straight to the reference documentation?**  Find it here.](https://spinframework.github.io/spin-js-sdk/stable/)
 
 The code below is an [Outbound MySQL example](https://github.com/spinframework/spin-js-sdk/tree/main/examples/spin-host-apis/spin-mysql). There is also an outbound [PostgreSQL example](https://github.com/spinframework/spin-js-sdk/tree/main/examples/spin-host-apis/spin-postgres) available.
 

--- a/content/v3/redis-outbound.md
+++ b/content/v3/redis-outbound.md
@@ -89,9 +89,9 @@ You can find a complete Rust code example for using outbound Redis from an HTTP 
 
 {{ startTab "TypeScript"}}
 
-> [**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/spin-js-sdk/)
+> [**Want to go straight to the reference documentation?**  Find it here.](https://spinframework.github.io/spin-js-sdk/stable/)
 
-Redis functions are available on [the `Redis` module](https://fermyon.github.io/spin-js-sdk/modules/Redis.html). The function names match the operations above. For example:
+Redis functions are available on [the `Redis` module](https://spinframework.github.io/spin-js-sdk/stable/modules/Redis.html). The function names match the operations above. For example:
 
 ```javascript
 import { Redis } from "@fermyon/spin-sdk"

--- a/content/v3/serverless-ai-api-guide.md
+++ b/content/v3/serverless-ai-api-guide.md
@@ -116,9 +116,9 @@ The `infer_with_options` examples, operation:
 
 {{ startTab "Typescript"}}
 
-> [**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/spin-js-sdk/modules/Llm.html)
+> [**Want to go straight to the reference documentation?**  Find it here.](https://spinframework.github.io/spin-js-sdk/stable/modules/Llm.html)
 
-To use Serverless AI functions, [the `Llm` module](https://fermyon.github.io/spin-js-sdk/modules/Llm.html) from the Spin SDK provides two methods: `infer` and `generateEmbeddings`. For example: 
+To use Serverless AI functions, [the `Llm` module](https://spinframework.github.io/spin-js-sdk/stable/modules/Llm.html) from the Spin SDK provides two methods: `infer` and `generateEmbeddings`. For example: 
 
 ```javascript
 import { AutoRouter } from 'itty-router';
@@ -146,15 +146,15 @@ addEventListener('fetch', async (event: FetchEvent) => {
 `infer` operation:
 
 - It takes in the following arguments - model name, prompt and a optional third parameter for inferencing options. 
-- The model name is a string. There are enums for the inbuilt models (llama2-chat and codellama) in [`InferencingModels`](https://fermyon.github.io/spin-js-sdk/enums/Llm.InferencingModels.html).
-- The optional third parameter which is an [InferencingOptions](https://fermyon.github.io/spin-js-sdk/interfaces/Llm.InferencingOptions.html) interface allows you to specify parameters such as `maxTokens`, `repeatPenalty`, `repeatPenaltyLastNTokenCount`, `temperature`, `topK`, `topP`.  
-- The return value is an [`InferenceResult`](https://fermyon.github.io/spin-js-sdk/interfaces/Llm.EmbeddingResult.html).
+- The model name is a string. There are enums for the inbuilt models (llama2-chat and codellama) in [`InferencingModels`](https://spinframework.github.io/spin-js-sdk/stable/enums/Llm.InferencingModels.html).
+- The optional third parameter which is an [InferencingOptions](https://spinframework.github.io/spin-js-sdk/stable/interfaces/Llm.InferencingOptions.html) interface allows you to specify parameters such as `maxTokens`, `repeatPenalty`, `repeatPenaltyLastNTokenCount`, `temperature`, `topK`, `topP`.  
+- The return value is an [`InferenceResult`](https://spinframework.github.io/spin-js-sdk/stable/interfaces/Llm.EmbeddingResult.html).
 
 `generateEmbeddings` operation:
 
 - It takes two arguments - model name and list of strings to generate the embeddings for. 
-- The model name is a string. There are enums for the inbuilt models (AllMiniLmL6V2) in [`EmbeddingModels`](https://fermyon.github.io/spin-js-sdk/enums/Llm.EmbeddingModels.html).
-- The return value is an [`EmbeddingResult`](https://fermyon.github.io/spin-js-sdk/interfaces/Llm.EmbeddingResult.html)
+- The model name is a string. There are enums for the inbuilt models (AllMiniLmL6V2) in [`EmbeddingModels`](https://spinframework.github.io/spin-js-sdk/stable/enums/Llm.EmbeddingModels.html).
+- The return value is an [`EmbeddingResult`](https://spinframework.github.io/spin-js-sdk/stable/interfaces/Llm.EmbeddingResult.html)
 
 {{ blockEnd }}
 

--- a/content/v3/sqlite-api-guide.md
+++ b/content/v3/sqlite-api-guide.md
@@ -120,9 +120,9 @@ struct ToDo {
 
 {{ startTab "Typescript"}}
 
-> [**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/spin-js-sdk/modules/Sqlite.html)
+> [**Want to go straight to the reference documentation?**  Find it here.](https://spinframework.github.io/spin-js-sdk/stable/modules/Sqlite.html)
 
-To use SQLite functions, use [the `Sqlite.open` or `Sqlite.openDefault` function](https://fermyon.github.io/spin-js-sdk/modules/Sqlite.html) to obtain [a `SqliteConnection` object](https://fermyon.github.io/spin-js-sdk/interfaces/Sqlite.SqliteConnection.html). `SqliteConnection` provides the `execute` method as described above. For example:
+To use SQLite functions, use [the `Sqlite.open` or `Sqlite.openDefault` function](https://spinframework.github.io/spin-js-sdk/stable/modules/Sqlite.html) to obtain [a `SqliteConnection` object](https://spinframework.github.io/spin-js-sdk/stable/interfaces/Sqlite.SqliteConnection.html). `SqliteConnection` provides the `execute` method as described above. For example:
 
 ```javascript
 import { AutoRouter } from 'itty-router';

--- a/content/v3/variables.md
+++ b/content/v3/variables.md
@@ -134,7 +134,7 @@ async fn handle_api_call_with_token(_req: Request) -> anyhow::Result<impl IntoRe
 
 {{ startTab "TypeScript"}}
 
-> [**Want to go straight to the reference documentation?**  Find it here.](https://fermyon.github.io/spin-js-sdk/modules/Variables.html)
+> [**Want to go straight to the reference documentation?**  Find it here.](https://spinframework.github.io/spin-js-sdk/stable/modules/Variables.html)
 
 ```ts
 import { AutoRouter } from 'itty-router';

--- a/downloads/install.sh
+++ b/downloads/install.sh
@@ -96,10 +96,6 @@ if command -v ldd >/dev/null 2>&1 && [[ "$(ldd /bin/ls | grep -m1 'musl')" ]]; t
 fi
 
 case $OSTYPE in
-"linux-gnu"*)
-    OS="linux"
-    STATIC="false"
-    ;;
 "darwin"*)
     OS="macos"
     STATIC="false"
@@ -120,8 +116,8 @@ case $OSTYPE in
 esac
 
 # Check desired version. Default to latest if no desired version was requested
-if [[ $VERSION = "" ]]; then
-    VERSION=$(curl -so- https://github.com/spinframework/spin/releases | grep 'href="/fermyon/spin/releases/tag/v[0-9]*.[0-9]*.[0-9]*\"' | sed -E 's/.*\/fermyon\/spin\/releases\/tag\/(v[0-9\.]+)".*/\1/g' | head -1)
+if [[ -z $VERSION ]]; then
+    VERSION=$(curl -so- https://github.com/spinframework/spin/releases | grep 'href="/spinframework/spin/releases/tag/v[0-9]*.[0-9]*.[0-9]*\"' | sed -E 's/.*\/spinframework\/spin\/releases\/tag\/(v[0-9\.]+)".*/\1/g' | head -1)
 fi
 
 # Constructing download FILE and URL
@@ -145,7 +141,10 @@ fi
 
 # Download file, exit if not found - e.g. version does not exist
 fancy_print 0 "Step 1: Downloading: ${URL}"
-curl -fsOL $URL || (fancy_print 1 "Error downloading the file: ${FILE}"; exit 1)
+curl -fsOL $URL || (
+    fancy_print 1 "Error downloading the file: ${FILE}"
+    exit 1
+)
 fancy_print 0 "Done...\n"
 
 # Decompress the file
@@ -165,17 +164,21 @@ fancy_print 0 "Step 4: Installing default templates"
 ./spin templates install --git "https://github.com/spinframework/spin-python-sdk" --upgrade
 ./spin templates install --git "https://github.com/spinframework/spin-js-sdk" --upgrade
 
-fancy_print 0 "Step 5: Installing default plugins"
-./spin plugins update
-if [[ $VERSION = "canary" ]]; then
-    ./spin plugins install -u https://github.com/fermyon/cloud-plugin/releases/download/canary/cloud.json --yes
-else
-    ./spin plugins install cloud --yes
-fi
+if [[ $STATIC = "false" ]]; then
+    fancy_print 0 "Step 5: Installing default plugins"
+    ./spin plugins update
+    if [[ $VERSION = "canary" ]]; then
+        ./spin plugins install -u https://github.com/fermyon/cloud-plugin/releases/download/canary/cloud.json --yes
+    else
+        ./spin plugins install cloud --yes
+    fi
 
-if [[ $VERSION = "canary" ]]; then
-    fancy_print 3 "Warning: You are using canary Spin, but templates use latest stable SDKs."
-    fancy_print 3 "Be sure to update templates to point to 'canary' SDKs."
+    if [[ $VERSION = "canary" ]]; then
+        fancy_print 3 "Warning: You are using canary Spin, but templates use latest stable SDKs."
+        fancy_print 3 "Be sure to update templates to point to 'canary' SDKs."
+    fi
+else
+    fancy_print 0 "Step 5: Skipping plugin installation for OS with musl"
 fi
 # Direct to quicks-start doc
 fancy_print 0 "You're good to go. Check here for the next steps: https://spinframework.dev/quickstart"

--- a/downloads/install.sh
+++ b/downloads/install.sh
@@ -89,12 +89,28 @@ case $UNAME_ARC in
     ;;
 esac
 
+# If OS uses musl, set distinct OS type to ensure the binary
+# with statically linked libraries and dependencies is used
+if command -v ldd >/dev/null 2>&1 && [[ "$(ldd /bin/ls | grep -m1 'musl')" ]]; then
+    OSTYPE="linux-musl"
+fi
+
 case $OSTYPE in
 "linux-gnu"*)
     OS="linux"
+    STATIC="false"
     ;;
 "darwin"*)
     OS="macos"
+    STATIC="false"
+    ;;
+"linux-musl"*)
+    OS="linux"
+    STATIC="true"
+    ;;
+"linux"*)
+    OS="linux"
+    STATIC="false"
     ;;
 *)
     fancy_print 1 "The OSTYPE: ${OSTYPE} is not supported by this script."
@@ -109,17 +125,21 @@ if [[ $VERSION = "" ]]; then
 fi
 
 # Constructing download FILE and URL
-FILE="spin-${VERSION}-${OS}-${ARC}.tar.gz"
+if [[ $STATIC = "true" ]]; then
+    FILE="spin-${VERSION}-static-${OS}-${ARC}.tar.gz"
+else
+    FILE="spin-${VERSION}-${OS}-${ARC}.tar.gz"
+fi
 URL="https://github.com/spinframework/spin/releases/download/${VERSION}/${FILE}"
 
 # Establish the location of current working environment
 current_dir=$(pwd)
 
 # Define Spin directory name
-spin_directory_name=("/spin")
+spin_directory_name="/spin"
 
-if [ -d "${current_dir}${spin_directory_name}" ]; then
-    fancy_print 1 "Error: .${spin_directory_name} already exists, please delete ${current_dir}${spin_directory_name} and run the installer again."
+if [ -d "${current_dir}$spin_directory_name" ]; then
+    fancy_print 1 "Error: .$spin_directory_name already exists, please delete ${current_dir}$spin_directory_name and run the installer again."
     exit 1
 fi
 


### PR DESCRIPTION
This ports relevant changes to the Fermyon version of the docs since the site was forked.

The history of the new repo is a bit strange and stuff has been moved without clear traceability so I suspect the merge algorithm has done some guesswork here - I'll look over it when I can see the diff, of course, but please review carefully!

Some changes listed in https://github.com/spinframework/spin-docs/pull/28#issuecomment-2756072851 are omitted as they applied only to stuff in the wasm-languages section which is no longer in the new site.
