### PR TITLE
Fix broken cloud links

### DIFF
--- a/content/v1/cli-reference.md
+++ b/content/v1/cli-reference.md
@@ -522,19 +522,19 @@ SUBCOMMANDS:
 
 {{ startTab "v1.3"}}
 
-The `spin cloud` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference).
+The `spin cloud` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference).
 
 {{ blockEnd }}
 
 {{ startTab "v1.4"}}
 
-The `spin cloud` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference).
+The `spin cloud` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference).
 
 {{ blockEnd }}
 
 {{ startTab "v1.5"}}
 
-The `spin cloud` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference).
+The `spin cloud` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference).
 
 {{ blockEnd }}
 
@@ -689,19 +689,19 @@ OPTIONS:
 
 {{ startTab "v1.3"}}
 
-The `spin cloud deploy` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-deploy).
+The `spin cloud deploy` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference#spin-cloud-deploy).
 
 {{ blockEnd }}
 
 {{ startTab "v1.4"}}
 
-The `spin cloud deploy` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-deploy).
+The `spin cloud deploy` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference#spin-cloud-deploy).
 
 {{ blockEnd }}
 
 {{ startTab "v1.5"}}
 
-The `spin cloud deploy` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-deploy).
+The `spin cloud deploy` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference#spin-cloud-deploy).
 
 {{ blockEnd }}
 
@@ -888,19 +888,19 @@ OPTIONS:
 
 {{ startTab "v1.3"}}
 
-The `spin cloud login` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-login).
+The `spin cloud login` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference#spin-cloud-login).
 
 {{ blockEnd }}
 
 {{ startTab "v1.4"}}
 
-The `spin cloud login` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-login).
+The `spin cloud login` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference#spin-cloud-login).
 
 {{ blockEnd }}
 
 {{ startTab "v1.5"}}
 
-The `spin cloud login` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-login).
+The `spin cloud login` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference#spin-cloud-login).
 
 {{ blockEnd }}
 
@@ -913,19 +913,19 @@ The `spin cloud login` command is implemented by the [Fermyon Cloud Plugin](/clo
 
 {{ startTab "v1.3"}}
 
-The `spin cloud variables` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-variables).
+The `spin cloud variables` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference#spin-cloud-variables).
 
 {{ blockEnd }}
 
 {{ startTab "v1.4"}}
 
-The `spin cloud variables` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-variables).
+The `spin cloud variables` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference#spin-cloud-variables).
 
 {{ blockEnd }}
 
 {{ startTab "v1.5"}}
 
-The `spin cloud variables` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-variables).
+The `spin cloud variables` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference#spin-cloud-variables).
 
 {{ blockEnd }}
 

--- a/content/v1/running-apps.md
+++ b/content/v1/running-apps.md
@@ -137,4 +137,4 @@ For additional information about Spin's `watch` feature, please see the [Spin wa
 - Learn how to [create and update a Spin application](writing-apps)
 - Learn about how to [configure your application at runtime](dynamic-configuration)
 - See how to [package and distribute your application](registry-tutorial)
-- Try deploying your application to run in the [Fermyon Cloud](/cloud/quickstart)
+- Try deploying your application to run in the [Fermyon Cloud](https://developer.fermyon.com/cloud/quickstart)

--- a/content/v1/see-what-people-have-built-with-spin.md
+++ b/content/v1/see-what-people-have-built-with-spin.md
@@ -75,4 +75,4 @@ Check out our [NoOps and Serverless Are the Perfect Pair](https://www.fermyon.co
 - Try [running your application locally](running-apps)
 - Learn about how to [configure your application at runtime](dynamic-configuration)
 - Look up details in the [application manifest reference](manifest-reference)
-- Try deploying a Spin application to the [Fermyon Cloud](/cloud/quickstart)
+- Try deploying a Spin application to the [Fermyon Cloud](https://developer.fermyon.com/cloud/quickstart)

--- a/content/v1/spin-application-structure.md
+++ b/content/v1/spin-application-structure.md
@@ -205,4 +205,4 @@ This is the recommended Spin application structure.
 - Discover how Spin application authors [design and organise applications](see-what-people-have-built-with-spin)
 - Learn about how to [configure your application at runtime](dynamic-configuration)
 - Look up details in the [application manifest reference](manifest-reference)
-- Try deploying a Spin application to the [Fermyon Cloud](/cloud/quickstart)
+- Try deploying a Spin application to the [Fermyon Cloud](https://developer.fermyon.com/cloud/quickstart)

--- a/content/v1/sqlite-api-guide.md
+++ b/content/v1/sqlite-api-guide.md
@@ -26,7 +26,7 @@ By default, a given component of an app will not have access to any SQLite datab
 sqlite_databases = ["default"]
 ```
 
-> Note: To deploy your Database application to Fermyon Cloud using `spin cloud deploy`, see the [SQLite Database](/cloud/noops-sql-db#accessing-private-beta) section in the documentation. It covers signing up for the private beta and setting up your Cloud database tables and initial data.
+> Note: To deploy your Database application to Fermyon Cloud using `spin cloud deploy`, see the [SQLite Database](https://developer.fermyon.com/cloud/noops-sql-db#accessing-private-beta) section in the documentation. It covers signing up for the private beta and setting up your Cloud database tables and initial data.
 
 ## Using SQLite Storage From Applications
 

--- a/content/v1/writing-apps.md
+++ b/content/v1/writing-apps.md
@@ -404,4 +404,4 @@ channel = "messages"
 - Discover how Spin application authors [design and organise applications](see-what-people-have-built-with-spin)
 - Learn about how to [configure your application at runtime](dynamic-configuration)
 - Look up details in the [application manifest reference](manifest-reference)
-- Try deploying a Spin application to the [Fermyon Cloud](/cloud/quickstart)
+- Try deploying a Spin application to the [Fermyon Cloud](https://developer.fermyon.com/cloud/quickstart)

--- a/content/v2/build.md
+++ b/content/v2/build.md
@@ -204,4 +204,4 @@ workdir = "deep"
 ## Next Steps
 
 - Try [running your application locally](running-apps)
-- Try deploying a Spin application to the [Fermyon Cloud](/cloud/quickstart)
+- Try deploying a Spin application to the [Fermyon Cloud](https://developer.fermyon.com/cloud/quickstart)

--- a/content/v2/cli-reference.md
+++ b/content/v2/cli-reference.md
@@ -571,43 +571,43 @@ OPTIONS:
 
 {{ startTab "v2.0"}}
 
-The `spin cloud` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference).
+The `spin cloud` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference).
 
 {{ blockEnd }}
 
 {{ startTab "v2.1"}}
 
-The `spin cloud` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference).
+The `spin cloud` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference).
 
 {{ blockEnd }}
 
 {{ startTab "v2.3"}}
 
-The `spin cloud` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference).
+The `spin cloud` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference).
 
 {{ blockEnd }}
 
 {{ startTab "v2.4"}}
 
-The `spin cloud` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference).
+The `spin cloud` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference).
 
 {{ blockEnd }}
 
 {{ startTab "v2.5"}}
 
-The `spin cloud` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference).
+The `spin cloud` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference).
 
 {{ blockEnd }}
 
 {{ startTab "v2.6"}}
 
-The `spin cloud` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference).
+The `spin cloud` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference).
 
 {{ blockEnd }}
 
 {{ startTab "v2.7"}}
 
-The `spin cloud` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference).
+The `spin cloud` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference).
 
 {{ blockEnd }}
 
@@ -621,43 +621,43 @@ The `spin cloud` command is implemented by the [Fermyon Cloud Plugin](/cloud/clo
 
 {{ startTab "v2.0"}}
 
-The `spin cloud apps` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-apps).
+The `spin cloud apps` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference#spin-cloud-apps).
 
 {{ blockEnd }}
 
 {{ startTab "v2.1"}}
 
-The `spin cloud apps` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-apps).
+The `spin cloud apps` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference#spin-cloud-apps).
 
 {{ blockEnd }}
 
 {{ startTab "v2.3"}}
 
-The `spin cloud apps` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-apps).
+The `spin cloud apps` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference#spin-cloud-apps).
 
 {{ blockEnd }}
 
 {{ startTab "v2.4"}}
 
-The `spin cloud apps` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-apps).
+The `spin cloud apps` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference#spin-cloud-apps).
 
 {{ blockEnd }}
 
 {{ startTab "v2.5"}}
 
-The `spin cloud apps` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-apps).
+The `spin cloud apps` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference#spin-cloud-apps).
 
 {{ blockEnd }}
 
 {{ startTab "v2.6"}}
 
-The `spin cloud apps` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-apps).
+The `spin cloud apps` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference#spin-cloud-apps).
 
 {{ blockEnd }}
 
 {{ startTab "v2.7"}}
 
-The `spin cloud apps` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-apps).
+The `spin cloud apps` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference#spin-cloud-apps).
 
 {{ blockEnd }}
 
@@ -671,43 +671,43 @@ The `spin cloud apps` command is implemented by the [Fermyon Cloud Plugin](/clou
 
 {{ startTab "v2.0"}}
 
-The `spin cloud deploy` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-deploy).
+The `spin cloud deploy` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference#spin-cloud-deploy).
 
 {{ blockEnd }}
 
 {{ startTab "v2.1"}}
 
-The `spin cloud deploy` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-deploy).
+The `spin cloud deploy` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference#spin-cloud-deploy).
 
 {{ blockEnd }}
 
 {{ startTab "v2.3"}}
 
-The `spin cloud deploy` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-deploy).
+The `spin cloud deploy` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference#spin-cloud-deploy).
 
 {{ blockEnd }}
 
 {{ startTab "v2.4"}}
 
-The `spin cloud deploy` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-deploy).
+The `spin cloud deploy` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference#spin-cloud-deploy).
 
 {{ blockEnd }}
 
 {{ startTab "v2.5"}}
 
-The `spin cloud deploy` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-deploy).
+The `spin cloud deploy` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference#spin-cloud-deploy).
 
 {{ blockEnd }}
 
 {{ startTab "v2.6"}}
 
-The `spin cloud deploy` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-deploy).
+The `spin cloud deploy` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference#spin-cloud-deploy).
 
 {{ blockEnd }}
 
 {{ startTab "v2.7"}}
 
-The `spin cloud deploy` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-deploy).
+The `spin cloud deploy` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference#spin-cloud-deploy).
 
 {{ blockEnd }}
 
@@ -721,43 +721,43 @@ The `spin cloud deploy` command is implemented by the [Fermyon Cloud Plugin](/cl
 
 {{ startTab "v2.0"}}
 
-The `spin cloud link` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-link).
+The `spin cloud link` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference#spin-cloud-link).
 
 {{ blockEnd }}
 
 {{ startTab "v2.1"}}
 
-The `spin cloud link` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-link).
+The `spin cloud link` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference#spin-cloud-link).
 
 {{ blockEnd }}
 
 {{ startTab "v2.3"}}
 
-The `spin cloud link` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-link).
+The `spin cloud link` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference#spin-cloud-link).
 
 {{ blockEnd }}
 
 {{ startTab "v2.4"}}
 
-The `spin cloud link` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-link).
+The `spin cloud link` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference#spin-cloud-link).
 
 {{ blockEnd }}
 
 {{ startTab "v2.5"}}
 
-The `spin cloud link` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-link).
+The `spin cloud link` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference#spin-cloud-link).
 
 {{ blockEnd }}
 
 {{ startTab "v2.6"}}
 
-The `spin cloud link` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-link).
+The `spin cloud link` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference#spin-cloud-link).
 
 {{ blockEnd }}
 
 {{ startTab "v2.7"}}
 
-The `spin cloud link` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-link).
+The `spin cloud link` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference#spin-cloud-link).
 
 {{ blockEnd }}
 
@@ -771,43 +771,43 @@ The `spin cloud link` command is implemented by the [Fermyon Cloud Plugin](/clou
 
 {{ startTab "v2.0"}}
 
-The `spin cloud login` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-login).
+The `spin cloud login` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference#spin-cloud-login).
 
 {{ blockEnd }}
 
 {{ startTab "v2.1"}}
 
-The `spin cloud login` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-login).
+The `spin cloud login` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference#spin-cloud-login).
 
 {{ blockEnd }}
 
 {{ startTab "v2.3"}}
 
-The `spin cloud login` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-login).
+The `spin cloud login` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference#spin-cloud-login).
 
 {{ blockEnd }}
 
 {{ startTab "v2.4"}}
 
-The `spin cloud login` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-login).
+The `spin cloud login` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference#spin-cloud-login).
 
 {{ blockEnd }}
 
 {{ startTab "v2.5"}}
 
-The `spin cloud login` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-login).
+The `spin cloud login` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference#spin-cloud-login).
 
 {{ blockEnd }}
 
 {{ startTab "v2.6"}}
 
-The `spin cloud login` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-login).
+The `spin cloud login` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference#spin-cloud-login).
 
 {{ blockEnd }}
 
 {{ startTab "v2.7"}}
 
-The `spin cloud login` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-login).
+The `spin cloud login` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference#spin-cloud-login).
 
 {{ blockEnd }}
 
@@ -821,43 +821,43 @@ The `spin cloud login` command is implemented by the [Fermyon Cloud Plugin](/clo
 
 {{ startTab "v2.0"}}
 
-The `spin cloud sqlite` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-sqlite).
+The `spin cloud sqlite` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference#spin-cloud-sqlite).
 
 {{ blockEnd }}
 
 {{ startTab "v2.1"}}
 
-The `spin cloud sqlite` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-sqlite).
+The `spin cloud sqlite` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference#spin-cloud-sqlite).
 
 {{ blockEnd }}
 
 {{ startTab "v2.3"}}
 
-The `spin cloud sqlite` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-sqlite).
+The `spin cloud sqlite` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference#spin-cloud-sqlite).
 
 {{ blockEnd }}
 
 {{ startTab "v2.4"}}
 
-The `spin cloud sqlite` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-sqlite).
+The `spin cloud sqlite` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference#spin-cloud-sqlite).
 
 {{ blockEnd }}
 
 {{ startTab "v2.5"}}
 
-The `spin cloud sqlite` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-sqlite).
+The `spin cloud sqlite` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference#spin-cloud-sqlite).
 
 {{ blockEnd }}
 
 {{ startTab "v2.6"}}
 
-The `spin cloud sqlite` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-sqlite).
+The `spin cloud sqlite` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference#spin-cloud-sqlite).
 
 {{ blockEnd }}
 
 {{ startTab "v2.7"}}
 
-The `spin cloud sqlite` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-sqlite).
+The `spin cloud sqlite` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference#spin-cloud-sqlite).
 
 {{ blockEnd }}
 
@@ -871,43 +871,43 @@ The `spin cloud sqlite` command is implemented by the [Fermyon Cloud Plugin](/cl
 
 {{ startTab "v2.0"}}
 
-The `spin cloud unlink` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-unlink).
+The `spin cloud unlink` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference#spin-cloud-unlink).
 
 {{ blockEnd }}
 
 {{ startTab "v2.1"}}
 
-The `spin cloud unlink` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-unlink).
+The `spin cloud unlink` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference#spin-cloud-unlink).
 
 {{ blockEnd }}
 
 {{ startTab "v2.3"}}
 
-The `spin cloud unlink` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-unlink).
+The `spin cloud unlink` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference#spin-cloud-unlink).
 
 {{ blockEnd }}
 
 {{ startTab "v2.4"}}
 
-The `spin cloud unlink` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-unlink).
+The `spin cloud unlink` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference#spin-cloud-unlink).
 
 {{ blockEnd }}
 
 {{ startTab "v2.5"}}
 
-The `spin cloud unlink` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-unlink).
+The `spin cloud unlink` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference#spin-cloud-unlink).
 
 {{ blockEnd }}
 
 {{ startTab "v2.6"}}
 
-The `spin cloud unlink` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-unlink).
+The `spin cloud unlink` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference#spin-cloud-unlink).
 
 {{ blockEnd }}
 
 {{ startTab "v2.7"}}
 
-The `spin cloud unlink` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-unlink).
+The `spin cloud unlink` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference#spin-cloud-unlink).
 
 {{ blockEnd }}
 
@@ -921,43 +921,43 @@ The `spin cloud unlink` command is implemented by the [Fermyon Cloud Plugin](/cl
 
 {{ startTab "v2.0"}}
 
-The `spin cloud variables` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-variables).
+The `spin cloud variables` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference#spin-cloud-variables).
 
 {{ blockEnd }}
 
 {{ startTab "v2.1"}}
 
-The `spin cloud variables` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-variables).
+The `spin cloud variables` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference#spin-cloud-variables).
 
 {{ blockEnd }}
 
 {{ startTab "v2.3"}}
 
-The `spin cloud variables` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-variables).
+The `spin cloud variables` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference#spin-cloud-variables).
 
 {{ blockEnd }}
 
 {{ startTab "v2.4"}}
 
-The `spin cloud variables` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-variables).
+The `spin cloud variables` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference#spin-cloud-variables).
 
 {{ blockEnd }}
 
 {{ startTab "v2.5"}}
 
-The `spin cloud variables` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-variables).
+The `spin cloud variables` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference#spin-cloud-variables).
 
 {{ blockEnd }}
 
 {{ startTab "v2.6"}}
 
-The `spin cloud variables` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-variables).
+The `spin cloud variables` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference#spin-cloud-variables).
 
 {{ blockEnd }}
 
 {{ startTab "v2.7"}}
 
-The `spin cloud variables` command is implemented by the [Fermyon Cloud Plugin](/cloud/cloud-command-reference#spin-cloud-variables).
+The `spin cloud variables` command is implemented by the [Fermyon Cloud Plugin](https://developer.fermyon.com/cloud/cloud-command-reference#spin-cloud-variables).
 
 {{ blockEnd }}
 

--- a/content/v2/dynamic-configuration.md
+++ b/content/v2/dynamic-configuration.md
@@ -262,7 +262,7 @@ container = "<cosmos-container>"
 
 Whilst a single default store may be sufficient for certain application use cases, each Spin application can be configured to support multiple stores of any `type`, as shown in the `runtime-config.toml` file below:
 
-> **Note:** At present, when deploying an application to Fermyon Cloud only the single "default" key-value store is supported. To see more about Spin support on Fermyon Cloud, visit the [limitations documentation](/cloud/faq#spin-limitations):
+> **Note:** At present, when deploying an application to Fermyon Cloud only the single "default" key-value store is supported. To see more about Spin support on Fermyon Cloud, visit the [limitations documentation](https://developer.fermyon.com/cloud/faq#spin-limitations):
 
 ```toml
 # This defines a new store named user_data

--- a/content/v2/index.md
+++ b/content/v2/index.md
@@ -28,4 +28,4 @@ Or dive into the documentation and get started:
 - [Take Spin for a spin](quickstart)
 - [Install Spin](install)
 - [Learn how to write Spin applications](writing-apps)
-- [Run your Spin applications in the Fermyon Cloud](/cloud/index)
+- [Run your Spin applications in the Fermyon Cloud](https://developer.fermyon.com/cloud/index)

--- a/content/v2/quickstart.md
+++ b/content/v2/quickstart.md
@@ -971,4 +971,4 @@ Congratulations again - you've now deployed your first Spin application to [Ferm
 
 - Learn more about [writing Spin components and manifests](writing-apps)
 - Learn how to [build your Spin application code](build)
-- Learn more about [Fermyon Cloud](/cloud/index)
+- Learn more about [Fermyon Cloud](https://developer.fermyon.com/cloud/index)

--- a/content/v2/running-apps.md
+++ b/content/v2/running-apps.md
@@ -164,4 +164,4 @@ Some people find it frustrating having to remember to build their applications b
 - Learn how to [create and update a Spin application](writing-apps)
 - Learn about how to [configure your application at runtime](dynamic-configuration)
 - See how to [package and distribute your application](registry-tutorial)
-- Try deploying your application to run in the [Fermyon Cloud](/cloud/quickstart)
+- Try deploying your application to run in the [Fermyon Cloud](https://developer.fermyon.com/cloud/quickstart)

--- a/content/v2/see-what-people-have-built-with-spin.md
+++ b/content/v2/see-what-people-have-built-with-spin.md
@@ -79,4 +79,4 @@ Check out our [NoOps and Serverless Are the Perfect Pair](https://www.fermyon.co
 - Try [running your application locally](running-apps)
 - Learn about how to [configure your application at runtime](dynamic-configuration)
 - Look up details in the [application manifest reference](manifest-reference)
-- Try deploying a Spin application to the [Fermyon Cloud](/cloud/quickstart)
+- Try deploying a Spin application to the [Fermyon Cloud](https://developer.fermyon.com/cloud/quickstart)

--- a/content/v2/spin-application-structure.md
+++ b/content/v2/spin-application-structure.md
@@ -215,4 +215,4 @@ This is the recommended Spin application structure.
 - Discover how Spin application authors [design and organise applications](see-what-people-have-built-with-spin)
 - Learn about how to [configure your application at runtime](dynamic-configuration)
 - Look up details in the [application manifest reference](manifest-reference)
-- Try deploying a Spin application to the [Fermyon Cloud](/cloud/quickstart)
+- Try deploying a Spin application to the [Fermyon Cloud](https://developer.fermyon.com/cloud/quickstart)

--- a/content/v2/sqlite-api-guide.md
+++ b/content/v2/sqlite-api-guide.md
@@ -25,7 +25,7 @@ By default, a given component of an app will not have access to any SQLite Datab
 sqlite_databases = ["default"]
 ```
 
-> Note: To deploy your Database application to Fermyon Cloud using `spin cloud deploy`, see the [SQLite Database](/cloud/noops-sql-db#accessing-private-beta) section in the documentation. It covers signing up for the private beta and setting up your Cloud database tables and initial data.
+> Note: To deploy your Database application to Fermyon Cloud using `spin cloud deploy`, see the [SQLite Database](https://developer.fermyon.com/cloud/noops-sql-db#accessing-private-beta) section in the documentation. It covers signing up for the private beta and setting up your Cloud database tables and initial data.
 
 ## Using SQLite Storage From Applications
 

--- a/content/v2/writing-apps.md
+++ b/content/v2/writing-apps.md
@@ -433,4 +433,4 @@ source = "spinredis.wasm"
 - Discover how Spin application authors [design and organise applications](see-what-people-have-built-with-spin)
 - Learn about how to [configure your application at runtime](dynamic-configuration)
 - Look up details in the [application manifest reference](manifest-reference)
-- Try deploying a Spin application to the [Fermyon Cloud](/cloud/quickstart)
+- Try deploying a Spin application to the [Fermyon Cloud](https://developer.fermyon.com/cloud/quickstart)

--- a/content/v3/build.md
+++ b/content/v3/build.md
@@ -206,4 +206,4 @@ workdir = "deep"
 ## Next Steps
 
 - Try [running your application locally](running-apps)
-- Try deploying a Spin application to the [Fermyon Cloud](/cloud/quickstart)
+- Try deploying a Spin application to the [Fermyon Cloud](https://developer.fermyon.com/cloud/quickstart)

--- a/content/v3/quickstart.md
+++ b/content/v3/quickstart.md
@@ -948,4 +948,4 @@ Congratulations again - you've now deployed your first Spin application to [Ferm
 
 - Learn more about [writing Spin components and manifests](writing-apps)
 - Learn how to [build your Spin application code](build)
-- Learn more about [Fermyon Cloud](/cloud/index)
+- Learn more about [Fermyon Cloud](https://developer.fermyon.com/cloud/index)

--- a/content/v3/running-apps.md
+++ b/content/v3/running-apps.md
@@ -199,4 +199,4 @@ Some people find it frustrating having to remember to build their applications b
 - Learn how to [create and update a Spin application](writing-apps)
 - Learn about how to [configure your application at runtime](dynamic-configuration)
 - See how to [package and distribute your application](registry-tutorial)
-- Try deploying your application to run in the [Fermyon Cloud](/cloud/quickstart)
+- Try deploying your application to run in the [Fermyon Cloud](https://developer.fermyon.com/cloud/quickstart)

--- a/content/v3/see-what-people-have-built-with-spin.md
+++ b/content/v3/see-what-people-have-built-with-spin.md
@@ -79,4 +79,4 @@ Check out our [NoOps and Serverless Are the Perfect Pair](https://www.fermyon.co
 - Try [running your application locally](running-apps)
 - Learn about how to [configure your application at runtime](dynamic-configuration)
 - Look up details in the [application manifest reference](manifest-reference)
-- Try deploying a Spin application to the [Fermyon Cloud](/cloud/quickstart)
+- Try deploying a Spin application to the [Fermyon Cloud](https://developer.fermyon.com/cloud/quickstart)

--- a/content/v3/spin-application-structure.md
+++ b/content/v3/spin-application-structure.md
@@ -215,4 +215,4 @@ This is the recommended Spin application structure.
 - Discover how Spin application authors [design and organise applications](see-what-people-have-built-with-spin)
 - Learn about how to [configure your application at runtime](dynamic-configuration)
 - Look up details in the [application manifest reference](manifest-reference)
-- Try deploying a Spin application to the [Fermyon Cloud](/cloud/quickstart)
+- Try deploying a Spin application to the [Fermyon Cloud](https://developer.fermyon.com/cloud/quickstart)

--- a/content/v3/sqlite-api-guide.md
+++ b/content/v3/sqlite-api-guide.md
@@ -25,7 +25,7 @@ By default, a given component of an app will not have access to any SQLite Datab
 sqlite_databases = ["default"]
 ```
 
-> Note: To deploy your Database application to Fermyon Cloud using `spin cloud deploy`, see the [SQLite Database](/cloud/noops-sql-db#accessing-private-beta) section in the documentation. It covers signing up for the private beta and setting up your Cloud database tables and initial data.
+> Note: To deploy your Database application to Fermyon Cloud using `spin cloud deploy`, see the [SQLite Database](https://developer.fermyon.com/cloud/noops-sql-db#accessing-private-beta) section in the documentation. It covers signing up for the private beta and setting up your Cloud database tables and initial data.
 
 ## Using SQLite Storage From Applications
 

--- a/content/v3/writing-apps.md
+++ b/content/v3/writing-apps.md
@@ -527,4 +527,4 @@ This grants _all_ dependencies access to _all_ resources listed in the Spin comp
 - Discover how Spin application authors [design and organise applications](see-what-people-have-built-with-spin)
 - Learn about how to [configure your application at runtime](dynamic-configuration)
 - Look up details in the [application manifest reference](manifest-reference)
-- Try deploying a Spin application to the [Fermyon Cloud](/cloud/quickstart)
+- Try deploying a Spin application to the [Fermyon Cloud](https://developer.fermyon.com/cloud/quickstart)


### PR DESCRIPTION
Fixes #31 

This is to fix breakage.  We will remove these or replace these links with vendor-neutral references in a later pass