### PR TITLE
fix(templates): rm missing blog and tutorials links

### DIFF
--- a/templates/content_navbar.hbs
+++ b/templates/content_navbar.hbs
@@ -27,7 +27,7 @@
                 <small>Browse example app code and templates</small>
             </a>
 
-            <a class="navbar-item plausible-event-name=docs-nav-hub navbar-stack" href="/blog" title="Sample apps, plugins and templates in Spin Hub">
+            {{!-- <a class="navbar-item plausible-event-name=docs-nav-hub navbar-stack" href="/blog" title="Sample apps, plugins and templates in Spin Hub">
                 <strong>Blog</strong>
                 <small>Latest community posts about Spin</small>
             </a>
@@ -35,7 +35,7 @@
             <a class="navbar-item plausible-event-name=docs-nav-hub navbar-stack" href="/tutorials" title="Sample apps, plugins and templates in Spin Hub">
                 <strong>Tutorials</strong>
                 <small>Starter guides for Spin's features</small>
-            </a>
+            </a> --}}
         </div>
 
         <div class="navbar-end">


### PR DESCRIPTION
- Removes the blog and tutorials links from the navbar as they currently lead to 404s

Fixes https://github.com/spinframework/spin-docs/issues/24