### PR TITLE
fix(.build): re-add localhost:16686 to exemptions

### DIFF
--- a/.build/check-broken-links.sh
+++ b/.build/check-broken-links.sh
@@ -83,6 +83,7 @@ blc --recursive http://127.0.0.1:3000                                           
     --exclude 'https://crates.io/crates/bytes'                                                                                                                                              \
     --exclude 'https://crates.io/crates/http'                                                                                                                                               \
     --exclude 'https://marketplace.visualstudio.com/items?itemName=yzhang.markdown-all-in-one'                                                                                              \
+    --exclude 'http://localhost:16686/'                                                                                                                                                     \
     --exclude 'http://localhost:5050/explore' | tee "${report}" || blc_error=true
 
 cat "${report}" | grep "├─BROKEN─" > broken_links || true


### PR DESCRIPTION
- Re-adds `localhost:16686` to the exemptions, mistakenly removed in https://github.com/spinframework/spin-docs/pull/38

Note: needs https://github.com/spinframework/spin-docs/pull/41 to pass the link checker.