### PR TITLE
add cookieless analytics to the site

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -601,6 +601,7 @@ var _utils = require("./modules/utils");
 var _multiTab = require("./modules/multiTab");
 var _feedback = require("./modules/feedback");
 const { mount } = redom;
+
 document.querySelectorAll('.modal-button').forEach(function(el) {
     el.addEventListener('click', function() {
         var target = document.querySelector(el.getAttribute('data-target'));
@@ -627,7 +628,6 @@ document.addEventListener("DOMContentLoaded", function() {
     (0, _utils.header).init();
     hljs.highlightAll();
     if (navigator && navigator.clipboard) (0, _utils.addCopyButtons)(navigator.clipboard);
-    (0, _utils.removeExpiredEvents)();
     (0, _utils.addAnchorLinks)();
     (0, _utils.scrollSideMenu)();
     // changelogFilter()
@@ -638,30 +638,30 @@ document.addEventListener("DOMContentLoaded", function() {
         }, 150);
         (0, _utils.header).unpin();
     }
-    (async function() {
-        try {
-            await (0, _search.setupSearch)();
-            mount(document.getElementById("search-button-container"), (0, _search.searchButton));
-            mount(document.getElementById("search-modal-container"), (0, _search.searchModal));
-            document.onkeydown = function(e) {
-                if (e.key == "Escape") (0, _search.searchModal).close();
-                if ((e.key == "k" || e.key == "K") && (e.metaKey || e.ctrlKey)) {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    (0, _search.searchModal).open();
-                }
-                if (e.key == "s" || e.key == "S") {
-                    let searchBar = document.getElementById("hub-search-input");
-                    if (searchBar && document.activeElement != searchBar) {
-                        e.preventDefault();
-                        searchBar.focus();
-                    }
-                }
-            };
-        } catch (err) {
-            console.error("Could not setup search");
-        }
-    })();
+    // (async function() {
+    //     try {
+    //         await (0, _search.setupSearch)();
+    //         mount(document.getElementById("search-button-container"), (0, _search.searchButton));
+    //         mount(document.getElementById("search-modal-container"), (0, _search.searchModal));
+    //         document.onkeydown = function(e) {
+    //             if (e.key == "Escape") (0, _search.searchModal).close();
+    //             if ((e.key == "k" || e.key == "K") && (e.metaKey || e.ctrlKey)) {
+    //                 e.preventDefault();
+    //                 e.stopPropagation();
+    //                 (0, _search.searchModal).open();
+    //             }
+    //             if (e.key == "s" || e.key == "S") {
+    //                 let searchBar = document.getElementById("hub-search-input");
+    //                 if (searchBar && document.activeElement != searchBar) {
+    //                     e.preventDefault();
+    //                     searchBar.focus();
+    //                 }
+    //             }
+    //         };
+    //     } catch (err) {
+    //         console.error("Could not setup search");
+    //     }
+    // })();
     // Init feedback on docs pages
     let feedback = document.getElementById("feedback-wrapper");
     if (feedback) (0, _feedback.createFeedbackElement)(feedback);
@@ -1069,18 +1069,15 @@ parcelHelpers.defineInteropFlag(exports);
 parcelHelpers.export(exports, "scrollSideMenu", ()=>scrollSideMenu);
 parcelHelpers.export(exports, "addCopyButtons", ()=>addCopyButtons);
 parcelHelpers.export(exports, "addAnchorLinks", ()=>addAnchorLinks);
-parcelHelpers.export(exports, "changelogFilter", ()=>changelogFilter);
-parcelHelpers.export(exports, "removeExpiredEvents", ()=>removeExpiredEvents);
 parcelHelpers.export(exports, "header", ()=>header);
-parcelHelpers.export(exports, "blogAd", ()=>blogAd);
+
+// init headroom for sticky menu on upscroll
 var header = new Headroom(document.querySelector("#topbar"), {
     tolerance: 5,
     offset: 80
 });
-var blogAd = new Headroom(document.querySelector("#blogSlogan"), {
-    tolerance: 5,
-    offset: 300
-});
+
+// init side menu accordions
 function scrollSideMenu() {
     let sidemenu = document.querySelector("aside.menu");
     if (sidemenu) {
@@ -1098,6 +1095,8 @@ function scrollSideMenu() {
         }
     }
 }
+
+// copy to clipboard
 const svgCopy = '<svg xmlns="http://www.w3.org/2000/svg" height="24" width="24"viewBox="0 0 448 512"><!-- Font Awesome Free 5.15.4 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License) --><path d="M433.941 65.941l-51.882-51.882A48 48 0 0 0 348.118 0H176c-26.51 0-48 21.49-48 48v48H48c-26.51 0-48 21.49-48 48v320c0 26.51 21.49 48 48 48h224c26.51 0 48-21.49 48-48v-48h80c26.51 0 48-21.49 48-48V99.882a48 48 0 0 0-14.059-33.941zM266 464H54a6 6 0 0 1-6-6V150a6 6 0 0 1 6-6h74v224c0 26.51 21.49 48 48 48h96v42a6 6 0 0 1-6 6zm128-96H182a6 6 0 0 1-6-6V54a6 6 0 0 1 6-6h106v88c0 13.255 10.745 24 24 24h88v202a6 6 0 0 1-6 6zm6-256h-64V48h9.632c1.591 0 3.117.632 4.243 1.757l48.368 48.368a6 6 0 0 1 1.757 4.243V112z"/></svg>';
 const svgCheck = '<svg aria-hidden="true" height="24" viewBox="0 0 16 16" version="1.1" width="24" data-view-component="true"><path fill-rule="evenodd" fill="#18d1a5" d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z"></path></svg>';
 const addCopyButtons = (clipboard)=>{
@@ -1140,6 +1139,8 @@ const addCopyButtons = (clipboard)=>{
         pre.appendChild(button);
     });
 };
+
+// add clickable #anchors to markdown titles
 const addAnchorLinks = ()=>{
     const elementsToProcess = document.querySelectorAll(".content h1, .content h2, .content h3, .content h4, .content tr");
     elementsToProcess.forEach((element)=>{
@@ -1172,77 +1173,9 @@ const addAnchorLinks = ()=>{
         });
     });
 };
-function removeExpiredEvents() {
-    let events = document.querySelectorAll(".community-highlight .carousel-cell");
-    let eventsNumber = events.length;
-    if (eventsNumber) events.forEach((k)=>{
-        if (k.dataset.expirydate) {
-            let eventExpiryDate = new Date(k.dataset.expirydate);
-            if (eventExpiryDate < Date.now()) {
-                k.remove();
-                eventsNumber--;
-            }
-        }
-    });
-    else return;
-    if (eventsNumber) {
-        var elem = document.querySelector('.main-carousel');
-        var flkty = new Flickity(elem, {
-            // options
-            cellAlign: 'left',
-            contain: true
-        });
-        // element argument can be a selector string
-        //   for an individual element
-        var flkty = new Flickity('.main-carousel', {
-        });
-    } else {
-        let eventsCarousel = document.querySelector(".community-highlight");
-        eventsCarousel.innerHTML = `
-        <article class="community-highlight carousel-cell">
-        <a href="#">
-            <event>
-                <date>
-                </date>
-                <eventtitle>No upcoming Events
-                </eventtitle>
-                <p></p>
-                <img class="event-logo" />
-            </event>
-        </a>
-        </article>
-        `;
-    }
-}
-function changelogFilter() {
-    let changelogItems = Array.from(document.querySelectorAll(".changelog-item-title"));
-    if (changelogItems.length) {
-        let changelogTags = new Set([
-            "all_features"
-        ]);
-        changelogItems.map((k)=>{
-            JSON.parse(k.dataset.tags).forEach((item)=>changelogTags.add(item));
-        });
-        changelogTags = Array.from(changelogTags);
-        let changelogSelect = document.getElementById("changelog-select");
-        changelogTags.map((k)=>{
-            let opt = document.createElement('option');
-            opt.value = k;
-            opt.innerHTML = k;
-            changelogSelect.appendChild(opt);
-        });
-        changelogSelect.addEventListener("change", ()=>{
-            let selected = changelogSelect.value;
-            changelogItems.map((k)=>{
-                if (selected != "all_features" && !k.dataset.tags.includes(selected)) {
-                    console.log(k.parentElement);
-                    k.parentElement.style.display = "none";
-                } else k.parentElement.style.display = "flex";
-            });
-        });
-    }
-}
 
+
+// tabs for multiple languages
 },{"@parcel/transformer-js/src/esmodule-helpers.js":"j7FRh"}],"1bdXi":[function(require,module,exports,__globalThis) {
 var parcelHelpers = require("@parcel/transformer-js/src/esmodule-helpers.js");
 parcelHelpers.defineInteropFlag(exports);
@@ -1385,6 +1318,8 @@ function filterMultitabQuery() {
     return multitabQuery;
 }
 
+
+// user feedback thumbsup/down vote
 },{"@parcel/transformer-js/src/esmodule-helpers.js":"j7FRh"}],"c5ZDr":[function(require,module,exports,__globalThis) {
 var parcelHelpers = require("@parcel/transformer-js/src/esmodule-helpers.js");
 parcelHelpers.defineInteropFlag(exports);

--- a/templates/content_top.hbs
+++ b/templates/content_top.hbs
@@ -115,6 +115,17 @@
             document.documentElement.classList.toggle('dark-theme', mode === "dark");
         }
     </script>
+
+    <!-- add cookie-less analytics (posthog, plausible) -->
+    <script>
+        !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister unregister_for_session getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSurveysLoaded onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty createPersonProfile opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing debug getPageViewId captureTraceFeedback captureTraceMetric".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+        posthog.init('phc_U8YU0gnIHRNl41B0OwzSHCI56AvA2lz5JDpWDw64Bcu', {
+            api_host: 'https://us.i.posthog.com',
+            persistence: 'memory',
+            person_profiles: 'identified_only',
+        })
+    </script>
+    <script defer data-domain="spinframework.dev" src="https://plausible.io/js/script.outbound-links.pageview-props.tagged-events.js"></script>
 </head>
 
 <body class="documentation">


### PR DESCRIPTION
Adds some basic web analytics to the site, using [plausible](https://plausible.io/spinframework.dev/) and [posthog](https://us.posthog.com/project/143216/) - as there's currently nothing counting visits.

Additionally, I see the existing JS is throwing a variety of console errors, so I removed some scripts that were no longer relevant. The `static/js/main.js` file is pretty sprawling - mostly due to the now defunt search script. There's issue #7 to address that properly, but for now I commented out the portion that initializes it and causes a bunch of errors upon pageload. 

