### PR TITLE
Remove SQLite `close` method (hangover from v1)

### DIFF
--- a/content/v3/sqlite-api-guide.md
+++ b/content/v3/sqlite-api-guide.md
@@ -37,7 +37,6 @@ The set of operations is common across all SDKs:
 |------------|------------|---------|----------|
 | `open`  | name | connection  | Open the database with the specified name. If `name` is the string "default", the default database is opened, provided that the component that was granted access in the component manifest from `spin.toml`. Otherwise, `name` must refer to a store defined and configured in a [runtime configuration file](./dynamic-configuration.md#sqlite-storage-runtime-configuration) supplied with the application.|
 | `execute` | connection, sql, parameters | database records | Executes the SQL statement and returns the results of the statement. SELECT statements typically return records or scalars. INSERT, UPDATE, and DELETE statements typically return empty result sets, but may return values in some cases. The `execute` operation recognizes the [SQLite dialect of SQL](https://www.sqlite.org/lang.html). |
-| `close` | connection | - | Close the specified `connection`. |
 
 The exact detail of calling these operations from your application depends on your language:
 


### PR DESCRIPTION
Fixes #85 

This seems to have been carried over from pre-component model WITs when SQLite used a pseudo-resource.  Since v2, connection has been a resource, and the close method has been replaced by the implicit drop behaviour.

