### PR TITLE
Update footer and landing page to meet CNCF website guidelines

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -13,7 +13,7 @@ Spin uses Wasm because it is **sandboxed, portable, and fast**.  Millisecond col
 
 Many languages have Wasm implementations, so **developers don't have to learn new languages or libraries**.
 
-Spin is **open source**, under the aegis of the [CNCF](https://www.cncf.io/), and **built on standards**, meaning you can take your Spin applications anywhere.  There are Spin implementations for local development, for self-hosted servers, for Kubernetes, and for cloud-hosted services.
+Spin is an **open source** [Cloud Native Computing Foundation](https://www.cncf.io/) sandbox project. It is **built on standards**, meaning you can take your Spin applications anywhere.  There are Spin implementations for local development, for self-hosted servers, for Kubernetes, and for cloud-hosted services.
 
 **Want to see the kinds of things people are building with Spin?**  Check out what's [Built With Spin](./see-what-people-have-built-with-spin)!
 

--- a/templates/content_footer.hbs
+++ b/templates/content_footer.hbs
@@ -5,5 +5,12 @@
             <a class="navbar-item" href="https://twitter.com/spinframework" target="_blank">Twitter</a>
             <a class="navbar-item" href="https://cloud-native.slack.com/archives/C089NJ9G1V0" target="_blank">Slack</a>
         </div>
+        <div class="has-text-left mt-4" style="width: 100%;">
+            <p>
+                The Linux Foundation has registered trademarks and uses trademarks.
+                For a list of trademarks of The Linux Foundation, please see our
+                <a href="https://www.linuxfoundation.org/legal/trademark-usage" target="_blank">Trademark Usage page</a>.
+            </p>
+        </div>
     </nav>
 </footer>


### PR DESCRIPTION
This is a [sandbox project onboarding](https://github.com/cncf/sandbox/issues/330#issuecomment-2877588374) task.
According to guidelines, we need:
1.  the CNCF trademark in the footer
2. On homepage, the following statement: “We are a Cloud Native Computing Foundation sandbox project."
3. On homepage, the CNCF logo

Guidelines for trademark and CNCF project statement can be found here: https://github.com/cncf/foundation/blob/main/website-guidelines.md

This PR adds 1 and 2. I am not sure how to artfully insert the CNCF logo.

@flynnduism ideally the trademark line would fall under the other footer items; however, i have not been able to finagle the css. Any advise would be appreciated