### PR TITLE
fix spin version dropdown behavior

### DIFF
--- a/templates/main.hbs
+++ b/templates/main.hbs
@@ -11,12 +11,12 @@
                 <select class="version-dropdown"
                     onchange="this.options[this.selectedIndex].value && (window.location = this.options[this.selectedIndex].value);">
                     <option value="/v3/index">Spin v3.x</option>
-                    <option value="/v2/index" {{#if (active_project request.spin-full-url "/spin/v2/" )}} selected
-                        {{/if}}>Spin v2.x</option>
-                    <option value="/v1/index" {{#if (active_project request.spin-full-url "/spin/v1/" )}} selected
-                        {{/if}}>Spin v1.x</option>
+                    <option value="/v2/index" {{#if (active_project request.spin-full-url "/v2/" )}} selected {{/if}}>
+                        Spin v2.x</option>
+                    <option value="/v1/index" {{#if (active_project request.spin-full-url "/v1/" )}} selected {{/if}}>
+                        Spin v1.x</option>
                 </select>
-                
+
                 {{> sidebar }}
             </aside>
         </div>


### PR DESCRIPTION
Fixes the spin version selection dropdown. V3 was always the default selected because we were comparing to the wrong url path as the path changed during the migraiton of spin docs.

fixes #104 