### PR TITLE
fix(ci): pin fsevents to 2.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,9 @@
     "unified": "11.0.5",
     "yaml-front-matter": "^4.1.1"
   },
+  "overrides": {
+    "fsevents": "~2.3.3"
+  },
   "scripts": {
     "spin": "nodemon --watch content --watch static --watch templates --watch spin-up-hub --ext html,md,rhai,hbs,css,js --verbose --legacy-watch --signal SIGINT --exec 'npm run build-index && npm run build-hub-index && spin up --file spin.toml --quiet --env PREVIEW_MODE=$PREVIEW_MODE'",
     "bundle-scripts": "parcel watch static/js/src/main.js --dist-dir static/js --no-source-maps",


### PR DESCRIPTION
- intended fix for [recent errors in CI](https://github.com/spinframework/spin-docs/pull/148): `npm error notsup Unsupported platform for fsevents@1.2.13: wanted {"os":"darwin"} (current: {"os":"linux"})`.  The v1 version of fsevents appears to be deprecated but at least one of its parent deps doesn't yet have a release with it bumped to v2, hence the override.