### PR TITLE
spin-test uses workdir, not dir

### DIFF
--- a/content/v3/testing-apps.md
+++ b/content/v3/testing-apps.md
@@ -210,7 +210,7 @@ Then we edit the `my-app` application's manifest (the `spin.toml` file) by addin
 [component.my-component.tool.spin-test]
 source = "tests/target/wasm32-wasip1/release/tests.wasm"
 build = "cargo component build --release"
-dir = "tests"
+workdir = "tests"
 ```
 
 ## Updating the App to Pass the Tests


### PR DESCRIPTION
Currently the document uses `dir` to specify a working directory of spin-test, but actually it should be `workdir`.
I guess https://github.com/spinframework/spin-test/commit/1049332cedda035b41e3dcc2d42f8e04efd5ae7e replaced to workdir.
  