### PR TITLE
Set v4 as default version

### DIFF
--- a/templates/main.hbs
+++ b/templates/main.hbs
@@ -10,14 +10,14 @@
                 {{! This adds the version selector }}
                 <select class="version-dropdown"
                     onchange="this.options[this.selectedIndex].value && (window.location = this.options[this.selectedIndex].value);">
+                    <option value="/v4/index" {{#if (active_project request.spin-full-url "/v4/" )}} selected {{/if}}>
+                        Spin v4.x</option>
                     <option value="/v3/index" {{#if (active_project request.spin-full-url "/v3/" )}} selected {{/if}}>
                         Spin v3.x</option>
                     <option value="/v2/index" {{#if (active_project request.spin-full-url "/v2/" )}} selected {{/if}}>
                         Spin v2.x</option>
                     <option value="/v1/index" {{#if (active_project request.spin-full-url "/v1/" )}} selected {{/if}}>
                         Spin v1.x</option>
-                    <option value="/v4/index" {{#if (active_project request.spin-full-url "/v4/" )}} selected {{/if}}>
-                        Spin v4.x (Preview)</option>
                 </select>
 
                 {{#if (active_project request.spin-full-url "/v1/")}}
@@ -26,10 +26,10 @@
                     {{#if (active_project request.spin-full-url "/v2/")}}
                         {{> sidebar_v2 }}
                     {{else}}
-                        {{#if (active_project request.spin-full-url "/v4/")}}
-                            {{> sidebar_v4 }}
-                        {{else}}
+                        {{#if (active_project request.spin-full-url "/v3/")}}
                             {{> sidebar_v3 }}
+                        {{else}}
+                            {{> sidebar_v4 }}
                         {{/if}}
                     {{/if}}
                 {{/if}}


### PR DESCRIPTION
Getting this ready for when Spin 4 is out.  Merging this will make 4.x the default Spin version for docs.
