### PR TITLE
Update CLI reference to v4

### DIFF
--- a/content/v4/cli-reference.md
+++ b/content/v4/cli-reference.md
@@ -11,6 +11,7 @@ This document contains the help content for the `spin` command-line program.
 
 **Command Overview:**
 
+<!-- no toc -->
 * [`spin`↴](#spin)
 * [`spin add`↴](#spin-add)
 * [`spin build`↴](#spin-build)
@@ -42,8 +43,7 @@ This document contains the help content for the `spin` command-line program.
 
 The Spin CLI
 
-**Usage:** `USAGE:
-    spin <SUBCOMMAND>`
+**Usage:** `spin <COMMAND>`
 
 ###### **Subcommands:**
 
@@ -59,19 +59,13 @@ The Spin CLI
 * `up` — Start the Spin application
 * `watch` — Build and run the Spin application, rebuilding and restarting it when files change
 
-###### **Options:**
-
-* `--help <HELP>` — Print help information
-* `--version <VERSION>` — Print version information
-
 
 
 ## `spin add`
 
 Scaffold a new component into an existing application
 
-**Usage:** `spin USAGE:
-    add [OPTIONS] [NAME]`
+**Usage:** `spin add [OPTIONS] [NAME]`
 
 ###### **Arguments:**
 
@@ -80,18 +74,16 @@ Scaffold a new component into an existing application
 
 ###### **Options:**
 
-* `-a`, `--accept-defaults <ACCEPT-DEFAULTS>` — An optional argument that allows to skip prompts for the manifest file by accepting the defaults if available on the template
-* `--allow-overwrite <ALLOW-OVERWRITE>` — If the output directory already contains files, generate the new files into it without confirming, overwriting any existing files with the same names
+* `-a`, `--accept-defaults` — An optional argument that allows to skip prompts for the manifest file by accepting the defaults if available on the template
+* `--allow-overwrite` — If the output directory already contains files, generate the new files into it without confirming, overwriting any existing files with the same names
 * `-f`, `--file <APP_MANIFEST_FILE>` — Path to spin.toml
-* `--help <HELP>` — Print help information
-* `--init <INIT>` — Create the new application or component in the current directory
-* `--no-vcs <NO-VCS>` — An optional argument that allows to skip creating .gitignore
+* `--init` — Create the new application or component in the current directory
+* `--no-vcs` — An optional argument that allows to skip creating .gitignore
 * `-o`, `--output <OUTPUT_PATH>` — The directory in which to create the new application or component. The default is the name argument
 * `-t`, `--template <TEMPLATE_ID>` — The template from which to create the new application or component. Run `spin templates list` to see available options
 * `--tag <TAGS>` — Filter templates to select by tags
 * `-v`, `--value <VALUES>` — Parameter values to be passed to the template (in name=value format)
 * `--values-file <VALUES_FILE>` — A TOML file which contains parameter values in name = "value" format. Parameters passed as CLI option overwrite parameters specified in the file
-* `--version <VERSION>` — Print version information
 
 
 
@@ -99,8 +91,7 @@ Scaffold a new component into an existing application
 
 Build the Spin application
 
-**Usage:** `spin USAGE:
-    build [OPTIONS] [UP_ARGS]...`
+**Usage:** `spin build [OPTIONS] [UP_ARGS]...`
 
 ###### **Arguments:**
 
@@ -110,10 +101,10 @@ Build the Spin application
 
 * `-c`, `--component-id <COMPONENT_ID>` — Component ID to build. This can be specified multiple times. The default is all components
 * `-f`, `--from <APP_MANIFEST_FILE>` — The application to build. This may be a manifest (spin.toml) file, or a directory containing a spin.toml file. If omitted, it defaults to "spin.toml"
-* `--help <HELP>` — Print help information
-* `--skip-target-checks <SKIP-TARGET-CHECKS>` — By default, if the application manifest specifies one or more deployment targets, Spin checks that all components are compatible with those deployment targets. Specify this option to bypass those target checks
-* `-u`, `--up <UP>` — Run the application after building
-* `--version <VERSION>` — Print version information
+* `--profile <PROFILE>` — The build profile to build. The default is the anonymous profile (usually the release build)
+* `--skip-generate-wits` — By default, the build command generates WIT files for components' dependencies. Specify this option to bypass generating WITs
+* `--skip-target-checks` — By default, if the application manifest specifies one or more deployment targets, Spin checks that all components are compatible with those deployment targets. Specify this option to bypass those target checks
+* `-u`, `--up` — Run the application after building
 
 
 
@@ -121,17 +112,11 @@ Build the Spin application
 
 Package and upload an application to a deployment environment.
 
-**Usage:** `spin USAGE:
-    deploy`
+**Usage:** `spin deploy`
 
 ###### **Arguments:**
 
 * `<ARGS>` — All args to be passed through to the plugin
-
-###### **Options:**
-
-* `--help <HELP>` — Print help information
-* `--version <VERSION>` — Print version information
 
 
 
@@ -139,14 +124,11 @@ Package and upload an application to a deployment environment.
 
 Detect and fix problems with Spin applications
 
-**Usage:** `spin USAGE:
-    doctor [OPTIONS]`
+**Usage:** `spin doctor [OPTIONS]`
 
 ###### **Options:**
 
 * `-f`, `--from <APP_MANIFEST_FILE>` — The application to check. This may be a manifest (spin.toml) file, or a directory containing a spin.toml file. If omitted, it defaults to "spin.toml"
-* `--help <HELP>` — Print help information
-* `--version <VERSION>` — Print version information
 
 
 
@@ -154,17 +136,11 @@ Detect and fix problems with Spin applications
 
 Log into a deployment environment.
 
-**Usage:** `spin USAGE:
-    login`
+**Usage:** `spin login`
 
 ###### **Arguments:**
 
 * `<ARGS>` — All args to be passed through to the plugin
-
-###### **Options:**
-
-* `--help <HELP>` — Print help information
-* `--version <VERSION>` — Print version information
 
 
 
@@ -172,8 +148,7 @@ Log into a deployment environment.
 
 Scaffold a new application based on a template
 
-**Usage:** `spin USAGE:
-    new [OPTIONS] [NAME]`
+**Usage:** `spin new [OPTIONS] [NAME]`
 
 ###### **Arguments:**
 
@@ -182,17 +157,15 @@ Scaffold a new application based on a template
 
 ###### **Options:**
 
-* `-a`, `--accept-defaults <ACCEPT-DEFAULTS>` — An optional argument that allows to skip prompts for the manifest file by accepting the defaults if available on the template
-* `--allow-overwrite <ALLOW-OVERWRITE>` — If the output directory already contains files, generate the new files into it without confirming, overwriting any existing files with the same names
-* `--help <HELP>` — Print help information
-* `--init <INIT>` — Create the new application or component in the current directory
-* `--no-vcs <NO-VCS>` — An optional argument that allows to skip creating .gitignore
+* `-a`, `--accept-defaults` — An optional argument that allows to skip prompts for the manifest file by accepting the defaults if available on the template
+* `--allow-overwrite` — If the output directory already contains files, generate the new files into it without confirming, overwriting any existing files with the same names
+* `--init` — Create the new application or component in the current directory
+* `--no-vcs` — An optional argument that allows to skip creating .gitignore
 * `-o`, `--output <OUTPUT_PATH>` — The directory in which to create the new application or component. The default is the name argument
 * `-t`, `--template <TEMPLATE_ID>` — The template from which to create the new application or component. Run `spin templates list` to see available options
 * `--tag <TAGS>` — Filter templates to select by tags
 * `-v`, `--value <VALUES>` — Parameter values to be passed to the template (in name=value format)
 * `--values-file <VALUES_FILE>` — A TOML file which contains parameter values in name = "value" format. Parameters passed as CLI option overwrite parameters specified in the file
-* `--version <VERSION>` — Print version information
 
 
 
@@ -200,8 +173,7 @@ Scaffold a new application based on a template
 
 Install/uninstall Spin plugins
 
-**Usage:** `spin USAGE:
-    plugins <SUBCOMMAND>`
+**Usage:** `spin plugins <COMMAND>`
 
 ###### **Subcommands:**
 
@@ -213,11 +185,6 @@ Install/uninstall Spin plugins
 * `update` — Fetch the latest Spin plugins from the spin-plugins repository
 * `upgrade` — Upgrade one or all plugins
 
-###### **Options:**
-
-* `--help <HELP>` — Print help information
-* `--version <VERSION>` — Print version information
-
 
 
 ## `spin plugins install`
@@ -226,8 +193,7 @@ Install plugin from a manifest.
 
 The binary file and manifest of the plugin is copied to the local Spin plugins directory.
 
-**Usage:** `spin plugins USAGE:
-    install [OPTIONS] [PLUGIN_NAME]`
+**Usage:** `spin plugins install [OPTIONS] [PLUGIN_NAME]`
 
 ###### **Arguments:**
 
@@ -237,12 +203,10 @@ The binary file and manifest of the plugin is copied to the local Spin plugins d
 
 * `--auth-header-value <AUTH_HEADER_VALUE>` — Provide the value for the authorization header to be able to install a plugin from a private repository. (e.g) --auth-header-value "Bearer <token>"
 * `-f`, `--file <LOCAL_PLUGIN_MANIFEST>` — Path to local plugin manifest
-* `--help <HELP>` — Print help information
-* `--override-compatibility-check <OVERRIDE-COMPATIBILITY-CHECK>` — Overrides a failed compatibility check of the plugin with the current version of Spin
+* `--override-compatibility-check` — Overrides a failed compatibility check of the plugin with the current version of Spin
 * `-u`, `--url <REMOTE_PLUGIN_MANIFEST>` — URL of remote plugin manifest to install
 * `-v`, `--version <VERSION>` — Specific version of a plugin to be install from the centralized plugins repository
-* `--version <VERSION>` — Print version information
-* `-y`, `--yes <YES-TO-ALL>` — Skips prompt to accept the installation of the plugin
+* `-y`, `--yes` — Skips prompt to accept the installation of the plugin
 
 
 
@@ -250,20 +214,20 @@ The binary file and manifest of the plugin is copied to the local Spin plugins d
 
 List available or installed plugins
 
-**Usage:** `spin plugins USAGE:
-    list [OPTIONS]`
+**Usage:** `spin plugins list [OPTIONS]`
 
 ###### **Options:**
 
-* `--all <ALL>` — List all versions of plugins. This is the default behaviour
+* `--all` — List all versions of plugins. This is the default behaviour
 * `--filter <FILTER>` — Filter the list to plugins containing this string
-* `--format <FORMAT>` — The format in which to list the templates
+* `--format <FORMAT>` — The format in which to list the plugins
 
   Default value: `plain`
-* `--help <HELP>` — Print help information
-* `--installed <INSTALLED>` — List only installed plugins
-* `--summary <SUMMARY>` — List latest and installed versions of plugins
-* `--version <VERSION>` — Print version information
+
+  Possible values: `plain`, `json`
+
+* `--installed` — List only installed plugins
+* `--summary` — List latest and installed versions of plugins
 
 
 
@@ -271,8 +235,7 @@ List available or installed plugins
 
 Search for plugins by name
 
-**Usage:** `spin plugins USAGE:
-    search [OPTIONS] [FILTER]`
+**Usage:** `spin plugins search [OPTIONS] [FILTER]`
 
 ###### **Arguments:**
 
@@ -283,8 +246,9 @@ Search for plugins by name
 * `--format <FORMAT>` — The format in which to list the plugins
 
   Default value: `plain`
-* `--help <HELP>` — Print help information
-* `--version <VERSION>` — Print version information
+
+  Possible values: `plain`, `json`
+
 
 
 
@@ -292,17 +256,11 @@ Search for plugins by name
 
 Print information about a plugin
 
-**Usage:** `spin plugins USAGE:
-    show <NAME>`
+**Usage:** `spin plugins show <NAME>`
 
 ###### **Arguments:**
 
 * `<NAME>` — Name of Spin plugin
-
-###### **Options:**
-
-* `--help <HELP>` — Print help information
-* `--version <VERSION>` — Print version information
 
 
 
@@ -310,17 +268,11 @@ Print information about a plugin
 
 Remove a plugin from your installation
 
-**Usage:** `spin plugins USAGE:
-    uninstall <NAME>`
+**Usage:** `spin plugins uninstall <NAME>`
 
 ###### **Arguments:**
 
 * `<NAME>` — Name of Spin plugin
-
-###### **Options:**
-
-* `--help <HELP>` — Print help information
-* `--version <VERSION>` — Print version information
 
 
 
@@ -328,13 +280,7 @@ Remove a plugin from your installation
 
 Fetch the latest Spin plugins from the spin-plugins repository
 
-**Usage:** `spin plugins USAGE:
-    update`
-
-###### **Options:**
-
-* `--help <HELP>` — Print help information
-* `--version <VERSION>` — Print version information
+**Usage:** `spin plugins update`
 
 
 
@@ -342,8 +288,7 @@ Fetch the latest Spin plugins from the spin-plugins repository
 
 Upgrade one or all plugins
 
-**Usage:** `spin plugins USAGE:
-    upgrade [OPTIONS] [PLUGIN_NAME]`
+**Usage:** `spin plugins upgrade [OPTIONS] [PLUGIN_NAME]`
 
 ###### **Arguments:**
 
@@ -351,16 +296,14 @@ Upgrade one or all plugins
 
 ###### **Options:**
 
-* `-a`, `--all <ALL>` — Upgrade all plugins
+* `-a`, `--all` — Upgrade all plugins
 * `--auth-header-value <AUTH_HEADER_VALUE>` — Provide the value for the authorization header to be able to install a plugin from a private repository. (e.g) --auth-header-value "Bearer <token>"
-* `-d`, `--downgrade <DOWNGRADE>` — Allow downgrading a plugin's version
+* `-d`, `--downgrade` — Allow downgrading a plugin's version
 * `-f`, `--file <LOCAL_PLUGIN_MANIFEST>` — Path to local plugin manifest
-* `--help <HELP>` — Print help information
-* `--override-compatibility-check <OVERRIDE-COMPATIBILITY-CHECK>` — Overrides a failed compatibility check of the plugin with the current version of Spin
+* `--override-compatibility-check` — Overrides a failed compatibility check of the plugin with the current version of Spin
 * `-u`, `--url <REMOTE_PLUGIN_MANIFEST>` — Path to remote plugin manifest
 * `-v`, `--version <VERSION>` — Specific version of a plugin to be install from the centralized plugins repository
-* `--version <VERSION>` — Print version information
-* `-y`, `--yes <YES-TO-ALL>` — Skips prompt to accept the installation of the plugin[s]
+* `-y`, `--yes` — Skips prompt to accept the installation of the plugin[s]
 
 
 
@@ -368,8 +311,7 @@ Upgrade one or all plugins
 
 Commands for working with OCI registries to distribute applications
 
-**Usage:** `spin USAGE:
-    registry <SUBCOMMAND>`
+**Usage:** `spin registry <COMMAND>`
 
 ###### **Subcommands:**
 
@@ -377,19 +319,13 @@ Commands for working with OCI registries to distribute applications
 * `pull` — Pull a Spin application from a registry
 * `push` — Push a Spin application to a registry
 
-###### **Options:**
-
-* `--help <HELP>` — Print help information
-* `--version <VERSION>` — Print version information
-
 
 
 ## `spin registry login`
 
 Log in to a registry
 
-**Usage:** `spin registry USAGE:
-    login [OPTIONS] <SERVER>`
+**Usage:** `spin registry login [OPTIONS] <SERVER>`
 
 ###### **Arguments:**
 
@@ -397,11 +333,9 @@ Log in to a registry
 
 ###### **Options:**
 
-* `--help <HELP>` — Print help information
 * `-p`, `--password <PASSWORD>` — Password for the registry
-* `--password-stdin <PASSWORD-STDIN>` — Take the password from stdin
+* `--password-stdin` — Take the password from stdin
 * `-u`, `--username <USERNAME>` — Username for the registry
-* `--version <VERSION>` — Print version information
 
 
 
@@ -409,8 +343,7 @@ Log in to a registry
 
 Pull a Spin application from a registry
 
-**Usage:** `spin registry USAGE:
-    pull [OPTIONS] <REFERENCE>`
+**Usage:** `spin registry pull [OPTIONS] <REFERENCE>`
 
 ###### **Arguments:**
 
@@ -419,9 +352,7 @@ Pull a Spin application from a registry
 ###### **Options:**
 
 * `--cache-dir <CACHE_DIR>` — Cache directory for downloaded registry data
-* `--help <HELP>` — Print help information
-* `-k`, `--insecure <INSECURE>` — Ignore server certificate errors
-* `--version <VERSION>` — Print version information
+* `-k`, `--insecure` — Ignore server certificate errors
 
 
 
@@ -429,8 +360,7 @@ Pull a Spin application from a registry
 
 Push a Spin application to a registry
 
-**Usage:** `spin registry USAGE:
-    push [OPTIONS] <REFERENCE>`
+**Usage:** `spin registry push [OPTIONS] <REFERENCE>`
 
 ###### **Arguments:**
 
@@ -439,17 +369,16 @@ Push a Spin application to a registry
 ###### **Options:**
 
 * `--annotation <ANNOTATIONS>` — Specifies the OCI image manifest annotations (in key=value format). Any existing value will be overwritten. Can be used multiple times
-* `--build <BUILD>` — Specifies to perform `spin build` (with the default options) before pushing the application
+* `--build` — Specifies to perform `spin build` (with the default options) before pushing the application
 * `--cache-dir <CACHE_DIR>` — Cache directory for downloaded registry data
-* `--compose <COMPOSE>` — Compose component dependencies before pushing the application.
+* `--compose` — Compose component dependencies before pushing the application.
 
    The default is to compose before pushing, which maximises compatibility with different Spin runtime hosts. Turning composition off can optimise bandwidth for shared dependencies, but makes the pushed image incompatible with hosts that cannot carry out composition themselves.
 
   Default value: `true`
 * `-f`, `--from <APP_MANIFEST_FILE>` — The application to push. This may be a manifest (spin.toml) file, or a directory containing a spin.toml file. If omitted, it defaults to "spin.toml"
-* `--help <HELP>` — Print help information
-* `-k`, `--insecure <INSECURE>` — Ignore server certificate errors
-* `--version <VERSION>` — Print version information
+* `-k`, `--insecure` — Ignore server certificate errors
+* `--profile <PROFILE>` — The build profile to push. The default is the anonymous profile (usually the release build)
 
 
 
@@ -457,8 +386,7 @@ Push a Spin application to a registry
 
 Commands for working with WebAssembly component templates
 
-**Usage:** `spin USAGE:
-    templates <SUBCOMMAND>`
+**Usage:** `spin templates <COMMAND>`
 
 ###### **Subcommands:**
 
@@ -466,11 +394,6 @@ Commands for working with WebAssembly component templates
 * `list` — List the installed templates
 * `uninstall` — Remove a template from your installation
 * `upgrade` — Upgrade templates to match your current version of Spin
-
-###### **Options:**
-
-* `--help <HELP>` — Print help information
-* `--version <VERSION>` — Print version information
 
 
 
@@ -480,18 +403,15 @@ Install templates from a Git repository or local directory.
 
 The files of the templates are copied to the local template store: a directory in your data or home directory.
 
-**Usage:** `spin templates USAGE:
-    install [OPTIONS]`
+**Usage:** `spin templates install [OPTIONS]`
 
 ###### **Options:**
 
 * `--branch <BRANCH>` — The optional branch of the git repository
 * `--dir <FROM_DIR>` — Local directory containing the template(s) to install
 * `--git <FROM_GIT>` — The URL of the templates git repository. The templates must be in a git repository in a "templates" directory
-* `--help <HELP>` — Print help information
 * `--tar <FROM_TAR>` — URL to a tarball in .tar.gz format containing the template(s) to install
-* `--upgrade <UPDATE>` — If present, updates existing templates instead of skipping
-* `--version <VERSION>` — Print version information
+* `--upgrade` — If present, updates existing templates instead of skipping
 
 
 
@@ -499,15 +419,12 @@ The files of the templates are copied to the local template store: a directory i
 
 List the installed templates
 
-**Usage:** `spin templates USAGE:
-    list [OPTIONS]`
+**Usage:** `spin templates list [OPTIONS]`
 
 ###### **Options:**
 
-* `--help <HELP>` — Print help information
 * `--tag <TAGS>` — Filter templates matching all provided tags
-* `--verbose <VERBOSE>` — Whether to show additional template details in the list
-* `--version <VERSION>` — Print version information
+* `--verbose` — Whether to show additional template details in the list
 
 
 
@@ -515,17 +432,11 @@ List the installed templates
 
 Remove a template from your installation
 
-**Usage:** `spin templates USAGE:
-    uninstall <TEMPLATE_ID>`
+**Usage:** `spin templates uninstall <TEMPLATE_ID>`
 
 ###### **Arguments:**
 
 * `<TEMPLATE_ID>` — The template to uninstall
-
-###### **Options:**
-
-* `--help <HELP>` — Print help information
-* `--version <VERSION>` — Print version information
 
 
 
@@ -535,16 +446,13 @@ Upgrade templates to match your current version of Spin.
 
 The files of the templates are copied to the local template store: a directory in your data or home directory.
 
-**Usage:** `spin templates USAGE:
-    upgrade [OPTIONS]`
+**Usage:** `spin templates upgrade [OPTIONS]`
 
 ###### **Options:**
 
-* `--all <ALL>` — By default, Spin displays the list of installed repositories and prompts you to choose which to upgrade.  Pass this flag to upgrade all repositories without prompting
+* `--all` — By default, Spin displays the list of installed repositories and prompts you to choose which to upgrade.  Pass this flag to upgrade all repositories without prompting
 * `--branch <BRANCH>` — The optional branch of the git repository, if a specific repository is given
-* `--help <HELP>` — Print help information
 * `--repo <GIT_URL>` — By default, Spin displays the list of installed repositories and prompts you to choose which to upgrade.  Pass this flag to upgrade only the specified repository without prompting
-* `--version <VERSION>` — Print version information
 
 
 
@@ -552,30 +460,24 @@ The files of the templates are copied to the local template store: a directory i
 
 Start the Spin application
 
-**Usage:** `spin USAGE:
-    up [OPTIONS]`
-
-###### **Arguments:**
-
-* `<TRIGGER_ARGS>` — All other args, to be passed through to the trigger
+**Usage:** `spin up [OPTIONS]`
 
 ###### **Options:**
 
-* `--build <BUILD>` — For local apps, specifies to perform `spin build` (with the default options) before running the application.
+* `--build` — For local apps, specifies to perform `spin build` (with the default options) before running the application.
 
    This is ignored on remote applications, as they are already built.
 * `-c`, `--component-id <COMPONENTS>` — [Experimental] Component ID to run. This can be specified multiple times. The default is all components
 * `--cache-dir <CACHE_DIR>` — Cache directory for downloaded components and assets
-* `--direct-mounts <DIRECT-MOUNTS>` — For local apps with directory mounts and no excluded files, mount them directly instead of using a temporary directory.
+* `--direct-mounts` — For local apps with directory mounts and no excluded files, mount them directly instead of using a temporary directory.
 
    This allows you to update the assets on the host filesystem such that the updates are visible to the guest without a restart.  This cannot be used with registry apps or apps which use file patterns and/or exclusions.
 * `-e`, `--env <ENV>` — Pass an environment variable (key=value) to all components of the application
 * `-f`, `--from <APPLICATION>` — The application to run. This may be a manifest (spin.toml) file, a directory containing a spin.toml file, a remote registry reference, or a Wasm module (a .wasm file). If omitted, it defaults to "spin.toml"
-* `-h`, `--help <HELP>`
-* `--help <HELP>` — Print help information
-* `-k`, `--insecure <INSECURE>` — Ignore server certificate errors from a registry
+* `-h`, `--help`
+* `-k`, `--insecure` — Ignore server certificate errors from a registry
+* `--profile <PROFILE>` — The build profile to run. The default is the anonymous profile (usually the release build)
 * `--temp <TMP>` — Temporary directory for the static assets of the components
-* `--version <VERSION>` — Print version information
 
 
 
@@ -583,8 +485,7 @@ Start the Spin application
 
 Build and run the Spin application, rebuilding and restarting it when files change
 
-**Usage:** `spin USAGE:
-    watch [OPTIONS] [UP_ARGS]...`
+**Usage:** `spin watch [OPTIONS] [UP_ARGS]...`
 
 ###### **Arguments:**
 
@@ -592,14 +493,13 @@ Build and run the Spin application, rebuilding and restarting it when files chan
 
 ###### **Options:**
 
-* `-c`, `--clear <CLEAR>` — Clear the screen before each run
+* `-c`, `--clear` — Clear the screen before each run
 * `-d`, `--debounce <DEBOUNCE>` — Set the timeout between detected change and re-execution, in milliseconds
 
   Default value: `100`
 * `-f`, `--from <APP_MANIFEST_FILE>` — The application to watch. This may be a manifest (spin.toml) file, or a directory containing a spin.toml file. If omitted, it defaults to "spin.toml"
-* `--help <HELP>` — Print help information
-* `--skip-build <SKIP_BUILD>` — Only run the Spin application, restarting it when build artifacts change
-* `--version <VERSION>` — Print version information
+* `--profile <PROFILE>` — The build profile to build and run. The default is the anonymous profile (usually the release build)
+* `--skip-build` — Only run the Spin application, restarting it when build artifacts change
 
 
 
@@ -609,3 +509,4 @@ Build and run the Spin application, rebuilding and restarting it when files chan
     This document was generated automatically by
     <a href="https://crates.io/crates/clap-markdown"><code>clap-markdown</code></a>.
 </i></small>
+


### PR DESCRIPTION
I think there might be some nasties lurking from the Clap 4 update though - `spin up` has lost its description, and the same problem exists in `spin --help`.  I'll look for more and fix upstream.

ETA: okay it has whacked all the `spin up` options too.  I think what is going on is that `UpCommand` is no longer a clap `Command` with the metadata `clap-markdown` needs - it is a special thing that does its own custom parsing.  We have logic that makes it do parameter `--help` correctly, but the Markdown library doesn't see that (and nor does top level `--help`)...

ETA 2: I think I have fixed the missing options and description.  I'll PR those changes to Spin.  I haven't yet cracked the missing description in `spin --help`.
