### PR TITLE
Install cloud plugin for deploy

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -33,6 +33,7 @@ jobs:
         uses: fermyon/actions/spin/setup@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          plugins: cloud
 
       - name: Login to Fermyon Cloud
         run: spin cloud login --token "${{ secrets.FERMYON_CLOUD_TOKEN }}"


### PR DESCRIPTION
Deploys appear to be failing because `spin cloud` is not recognised as a command.  The deploy workflow use an old Fermyon setup action which I'm guessing runs the installer, which (as of v4) no longer includes the `cloud` plugin.

So this PR installs the plugin manually, and crosses its fingers.
